### PR TITLE
Misc/devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,13 @@
+FROM python:3.11-slim
+
+# Install git and other dependencies
+RUN apt-get update && apt-get install -y git && rm -rf /var/lib/apt/lists/*
+
+# Set up work directory
+WORKDIR /workspace
+
+# Install dependencies
+RUN pip install --upgrade pip
+    
+# Default command
+CMD ["sleep", "infinity"]

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,19 @@
+{
+    "name": "gaussian_toolbox Dev Container",
+    "build": {
+      "dockerfile": "Dockerfile"
+    },
+    "customizations": {
+      "vscode": {
+        "extensions": [
+          "ms-python.python",
+          "ms-python.vscode-pylance",
+          "ms-toolsai.jupyter"
+        ]
+      }
+    },
+    "mounts": [
+      "source=vscode-extensions,target=/root/.vscode-server/extensions,type=volume"
+    ],
+    "postCreateCommand": "pip install -e . && pip install -r requirements.txt"
+  }

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,5 +1,11 @@
 name: Docs
-on: [push, pull_request, workflow_dispatch]
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+  workflow_dispatch:
+    branches: [ "main" ]
 jobs:
   docs:
     runs-on: ubuntu-latest

--- a/.github/workflows/draft-pdf.yml
+++ b/.github/workflows/draft-pdf.yml
@@ -1,23 +1,24 @@
-on: [push]
+# deactivate workflow
+# on: [push]
 
-jobs:
-  paper:
-    runs-on: ubuntu-latest
-    name: Paper Draft
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Build draft PDF
-        uses: openjournals/openjournals-draft-action@master
-        with:
-          journal: joss
-          # This should be the path to the paper within your repo.
-          paper-path: paper/paper.md
-      - name: Upload
-        uses: actions/upload-artifact@v1
-        with:
-          name: paper
-          # This is the output path where Pandoc will write the compiled
-          # PDF. Note, this should be the same directory as the input
-          # paper.md
-          path: paper/paper.pdf
+# jobs:
+#   paper:
+#     runs-on: ubuntu-latest
+#     name: Paper Draft
+#     steps:
+#       - name: Checkout
+#         uses: actions/checkout@v2
+#       - name: Build draft PDF
+#         uses: openjournals/openjournals-draft-action@master
+#         with:
+#           journal: joss
+#           # This should be the path to the paper within your repo.
+#           paper-path: paper/paper.md
+#       - name: Upload
+#         uses: actions/upload-artifact@v1
+#         with:
+#           name: paper
+#           # This is the output path where Pandoc will write the compiled
+#           # PDF. Note, this should be the same directory as the input
+#           # paper.md
+#           path: paper/paper.pdf

--- a/.gitignore
+++ b/.gitignore
@@ -345,3 +345,4 @@ gp_jax/
 ipynbs
 
 cov.xml
+

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,5 @@
+repos:
+- repo: https://github.com/kynan/nbstripout
+  rev: 0.8.1
+  hooks:
+    - id: nbstripout

--- a/README.md
+++ b/README.md
@@ -3,8 +3,9 @@
 [![tests](https://github.com//christiando/gaussian-toolbox/actions/workflows/python-app.yml/badge.svg)](https://github.com//christiando/gaussian-toolbox/actions/workflows/python-app.yml)
 [![codecov](https://codecov.io/github/christiando/gaussian-toolbox/branch/main/graph/badge.svg?token=IR47CKMXXD)](https://codecov.io/github/christiando/gaussian-toolbox)
 ![Docs](https://github.com/christiando/gaussian-toolbox/actions/workflows/docs.yml/badge.svg)
+![python](https://img.shields.io/badge/python-3.10-blue)
 
-The main motivation of this library is to make Gaussian manipulations as easy as possible. For this certain [object classes](/docs/source/notebooks/gaussian_objects.ipynb) are defined, which can be manipulated in the following way. The basic code tries to follow roughly this The code roughly follows this [note](http://users.isy.liu.se/en/rt/schon/Publications/SchonL2011.pdf).
+The main motivation of this library is to make Gaussian manipulations as easy as possible. For this certain [object classes](https://christiando.github.io/gaussian-toolbox/notebooks/gaussian_objects.html) are defined, which can be manipulated in the following way. The basic code tries to follow roughly this The code roughly follows this [note](http://users.isy.liu.se/en/rt/schon/Publications/SchonL2011.pdf).
 
 [**Basic Usage**](#basics) | [**Install guide**](#installation) | [**Citing**](#citation) | [**Documentation**](https://christiando.github.io/gaussian-toolbox/)
 
@@ -73,11 +74,11 @@ p_Y_given_X = ConditionalGaussianPDF(...)
 p_X_given_Y = p_Y_given_X.affine_conditional_transformation(p_X)
 ```
 
-Other operations that are provided are conditioning, marginalizing, getting the joint or marginal density. For a more exhaustive example see the [docs](/docs/source/notebooks/affine_transforms.ipynb)
+Other operations that are provided are conditioning, marginalizing, getting the joint or marginal density. For a more exhaustive example see the [docs](https://christiando.github.io/gaussian-toolbox/notebooks/affine_transforms.html)
 
 # And much more
 
-Based upon these operations and extensions thereof, basic models (e.g. [linear regression](/docs/source/notebooks/linear_regression.ipynb)), but also more complex models (e.g. for [time-series](/docs/source/notebooks/timeseries.ipynb)) can be implemented.
+Based upon these operations and extensions thereof, basic models (e.g. [linear regression](https://christiando.github.io/gaussian-toolbox/notebooks/linear_regression.html)), but also more complex models (e.g. for [time-series](https://christiando.github.io/gaussian-toolbox/notebooks/timeseries.html)) can be implemented.
 Furthermore, the `GT` is written completely with [JAX](https://github.com/google/jax/tree/main/docs), such that your code can run on GPU/TPU, can be just-in-time compiled, vectorized etc. Furthermore, it can be easily combined with other libraries like [optax](https://github.com/deepmind/optax) and [haiku](https://github.com/deepmind/dm-haiku). Combining Gaussian manipulations with neural networks has never been easier.
 
 Got interested? What can you do with it?

--- a/docs/source/gaussian_toolbox.rst
+++ b/docs/source/gaussian_toolbox.rst
@@ -5,12 +5,29 @@ Subpackages
 -----------
 
 .. toctree::
-   :maxdepth: 1
-   
+   :maxdepth: 4
+
+   gaussian_toolbox.experimental
    gaussian_toolbox.utils
 
 Submodules
 ----------
+
+gaussian\_toolbox.approximate\_conditional module
+-------------------------------------------------
+
+.. automodule:: gaussian_toolbox.approximate_conditional
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+gaussian\_toolbox.conditional module
+------------------------------------
+
+.. automodule:: gaussian_toolbox.conditional
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 gaussian\_toolbox.factor module
 -------------------------------
@@ -32,22 +49,6 @@ gaussian\_toolbox.pdf module
 ----------------------------
 
 .. automodule:: gaussian_toolbox.pdf
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-gaussian\_toolbox.conditional module
-------------------------------------
-
-.. automodule:: gaussian_toolbox.conditional
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-gaussian\_toolbox.approximate\_conditional module
--------------------------------------------------
-
-.. automodule:: gaussian_toolbox.approximate_conditional
    :members:
    :undoc-members:
    :show-inheritance:

--- a/docs/source/gaussian_toolbox.utils.rst
+++ b/docs/source/gaussian_toolbox.utils.rst
@@ -4,6 +4,14 @@ gaussian\_toolbox.utils package
 Submodules
 ----------
 
+gaussian\_toolbox.utils.dataclass module
+----------------------------------------
+
+.. automodule:: gaussian_toolbox.utils.dataclass
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 gaussian\_toolbox.utils.jax\_minimize\_wrapper module
 -----------------------------------------------------
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -24,7 +24,7 @@ Welcome to Gaussian Toolbox's documentation!
    notebooks/approximate_conditionals
 
 .. toctree::
-   :maxdepth: 1
+   :maxdepth: 2
    :caption: API
 
    gaussian_toolbox

--- a/examples/affine_transforms.ipynb
+++ b/examples/affine_transforms.ipynb
@@ -245,7 +245,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3.9.13 ('gaussian_toolbox')",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -259,12 +259,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.8 (main, Nov  4 2022, 13:48:29) [GCC 11.2.0]"
-  },
-  "vscode": {
-   "interpreter": {
-    "hash": "782cd5dadb26a54d425c88a99e91aaf22c15a8b7b364f1b6867d338206b7ed04"
-   }
+   "version": "3.11.11"
   }
  },
  "nbformat": 4,

--- a/examples/approximate_conditionals.ipynb
+++ b/examples/approximate_conditionals.ipynb
@@ -253,7 +253,6 @@
    "pygments_lexer": "ipython3",
    "version": "3.10.8"
   },
-  "orig_nbformat": 4,
   "vscode": {
    "interpreter": {
     "hash": "782cd5dadb26a54d425c88a99e91aaf22c15a8b7b364f1b6867d338206b7ed04"

--- a/examples/linear_regression.ipynb
+++ b/examples/linear_regression.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "78b9e0c4",
+   "id": "0",
    "metadata": {},
    "source": [
     "# Example: Bayesian linear regression\n",
@@ -22,7 +22,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5f740900",
+   "id": "1",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -37,7 +37,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7c438b48",
+   "id": "2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -67,7 +67,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c14c6eaf",
+   "id": "3",
    "metadata": {},
    "source": [
     "Let's now construct the _prior_ and the _likelihood_ in `GT`."
@@ -76,7 +76,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0f691a61",
+   "id": "4",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -105,7 +105,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d033115e",
+   "id": "5",
    "metadata": {},
    "source": [
     "In Bayesian inference we are interest in two particular objects. One is the _posterior_ over the model parameter $W$ given the data, and the other predictive density for new points $X=x^\\star$ given the posterior. We can get this objects with the affine transformations encountered before:\n",
@@ -121,7 +121,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "15691048",
+   "id": "6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -202,7 +202,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ad2da58c",
+   "id": "7",
    "metadata": {},
    "source": [
     "__One step inference__\n",
@@ -218,7 +218,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "03d2988e",
+   "id": "8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -256,7 +256,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9c79acb4",
+   "id": "9",
    "metadata": {},
    "source": [
     "__Bayesian linear regression with Neural network mean__\n",
@@ -269,7 +269,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ba0950c9",
+   "id": "10",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -298,7 +298,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c38bd653",
+   "id": "11",
    "metadata": {},
    "source": [
     "For such a case, the `GT` provides a new conditional object `NNControlGaussianConditional`\n",
@@ -313,7 +313,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "cf6cab9b",
+   "id": "12",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -348,7 +348,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "61019da4",
+   "id": "13",
    "metadata": {},
    "source": [
     "The only difference to the previous linear example is, that before using the `NNControlGaussianConditional` we need to set the control variables, which then returns a `ConditionalGaussianPDF` again.\n",
@@ -365,7 +365,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ff439940",
+   "id": "14",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -380,7 +380,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "64687798",
+   "id": "15",
    "metadata": {},
    "source": [
     "Since `GT` is based upon `jax` and `objax` optimization of $\\phi$ is quite straightforward. "
@@ -388,7 +388,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "048c4eba",
+   "id": "16",
    "metadata": {},
    "source": [
     "Now with the optimal $\\phi$ we just do inference as before, with the only difference, that we need to set the hyperparameters."
@@ -397,7 +397,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "33121be1",
+   "id": "17",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -434,7 +434,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "038759d3",
+   "id": "18",
    "metadata": {},
    "source": [
     "Of course, this is just a simple example. One more complex example is to paramterize also the covariance $\\Sigma$ via control variables. You want to try it yourself? ;)"

--- a/examples/timeseries.ipynb
+++ b/examples/timeseries.ipynb
@@ -3,7 +3,7 @@
   {
    "attachments": {},
    "cell_type": "markdown",
-   "id": "55007fce",
+   "id": "0",
    "metadata": {},
    "source": [
     "# Kalman Filter\n",
@@ -34,7 +34,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "090e228d",
+   "id": "1",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -56,7 +56,7 @@
   {
    "attachments": {},
    "cell_type": "markdown",
-   "id": "bbae830a",
+   "id": "2",
    "metadata": {},
    "source": [
     "Now we would like to sample data from the generative process, that is depicted by this two objects. For this we need an additional density, the initial density. Then we define a function that does one sample step and iterate that forward."
@@ -65,7 +65,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ea43eb5c",
+   "id": "3",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -104,7 +104,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5363b0d0",
+   "id": "4",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -123,7 +123,7 @@
   {
    "attachments": {},
    "cell_type": "markdown",
-   "id": "329dbd1e",
+   "id": "5",
    "metadata": {},
    "source": [
     "Now having data at hand we would like to estimate the density over latent variables and data again. Hence, we would like to iterate forward the Kalman filter, which consists of two steps.\n",
@@ -150,7 +150,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e19f76a6",
+   "id": "6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -181,7 +181,7 @@
   {
    "attachments": {},
    "cell_type": "markdown",
-   "id": "c2e8a5a3",
+   "id": "7",
    "metadata": {},
    "source": [
     "The Kalman filter provides the filter density over the latent state. If we want the data density we can do that in one line with `GT`."
@@ -190,7 +190,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "40e6c4fb",
+   "id": "8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -214,7 +214,7 @@
   {
    "attachments": {},
    "cell_type": "markdown",
-   "id": "efd4384d",
+   "id": "9",
    "metadata": {},
    "source": [
     "Of course, this is only demonstrating how to perform Kalman-Filter for the known model. But `GT` provides also utilities to e.g. simply calculate the Q-function, which is the objective in the expectation maximization procedure [[Dempster, 1976]](https://www.eng.auburn.edu/~roppeth/courses/00sum13/7970%202013A%20ADvMobRob%20sp13/literature/paper%20W%20refs/dempster%20EM%201977.pdf) to learn the model parameters."

--- a/gaussian_toolbox/approximate_conditional.py
+++ b/gaussian_toolbox/approximate_conditional.py
@@ -9,7 +9,11 @@ from .utils.dataclass import dataclass
 from jaxtyping import Array, Float, Int, Bool
 from jax import lax
 from jax import jit
+from jax import scipy as jsc
 
+from dataclasses import field
+from jax import random, vmap
+from abc import abstractmethod
 
 @dataclass(kw_only=True)
 class LConjugateFactorMGaussianConditional(conditional.ConditionalGaussianPDF):
@@ -108,6 +112,7 @@ class LConjugateFactorMGaussianConditional(conditional.ConditionalGaussianPDF):
         Sigma_y += MEfb + jnp.swapaxes(MEfb, axis1=1, axis2=2)
         Sigma_y += (self.b[0, None] * self.b[0, :, None])[None]
         Sigma_y -= mu_y[:, None] * mu_y[:, :, None]
+        Sigma_y = 0.5 * (Sigma_y + jnp.swapaxes(Sigma_y, axis1=-1, axis2=-2))
         return mu_y, Sigma_y
 
     def get_expected_cross_terms(self, p_x: pdf.GaussianPDF) -> Float[Array, "R Dx Dy"]:
@@ -202,6 +207,7 @@ class LConjugateFactorMGaussianConditional(conditional.ConditionalGaussianPDF):
         M_new = jnp.einsum("abc,abd->acd", cov_yx, Lambda_y)
         b_new = mu_x - jnp.einsum("abc,ac->ab", M_new, mu_y)
         Sigma_new = p_x.Sigma - jnp.einsum("abc,acd->abd", M_new, cov_yx)
+        Sigma_new = 0.5 * (Sigma_new + jnp.swapaxes(Sigma_new, -1, -2))
         cond_p_xy = conditional.ConditionalGaussianPDF(
             M=M_new,
             b=b_new,
@@ -502,7 +508,7 @@ class LSEMGaussianConditional(LConjugateFactorMGaussianConditional):
         RuntimeError: If neither Sigma nor Lambda are provided.
     """
 
-    M: Float[Array, "1 Dy Dk+Dx+1"]
+    M: Float[Array, "1 Dy Dk+Dx"]
     b: Float[Array, "1 Dy"]
     W: Float[Array, "Dk Dx+1"]
     Sigma: Float[Array, "1 Dy Dy"] = None
@@ -680,11 +686,10 @@ class LSEMGaussianConditional(LConjugateFactorMGaussianConditional):
             return log_expectation_y
         else:
             return log_expectation_y(y)
-
-
+        
 @dataclass(kw_only=True)
-class HCCovGaussianConditional(conditional.ConditionalGaussianPDF):
-    r"""A conditional Gaussian density, with a heteroscedastic cosh covariance (HCCov) function,
+class HeteroscedasticConditional(conditional.ConditionalGaussianPDF):
+    r"""A conditional Gaussian density, with a heteroscedastic covariance,
 
     .. math::
 
@@ -695,9 +700,9 @@ class HCCovGaussianConditional(conditional.ConditionalGaussianPDF):
 
     .. math::
 
-        \Sigma_y(x) = \sigma_x^2 I + \sum_i U_i D_i(x) U_i^\top,
+        \Sigma_y(x) = AA^\top + AD(x)A^\top.
 
-    and :math:`D_i(x) = 2 * \beta_i * \cosh(h_i(x))` and :math:`h_i(x) = w_i^\top x + b_i`.
+    and :math:`D_i(x) = \exp(h_i(x))` and :math:`h_i(x) = w_i^\top x + b_i`.
 
     Note, that the affine transformations will be approximated via moment matching.
 
@@ -714,22 +719,33 @@ class HCCovGaussianConditional(conditional.ConditionalGaussianPDF):
     """
     M: Float[Array, "1 Dy Dx"]
     b: Float[Array, "1 Dy"]
-    sigma_x: float
-    U: Float[Array, "Dy Du"]
-    W: Float[Array, "Du Dx+1"]
-    beta: Float[Array, "Du"]
-
+    A: Float[Array, "1 Dy Da"]
+    W: Float[Array, "Dk Dx+1"]
+    Sigma: Float[Array, "1 Dy Dy"] = field(default=None)
+    Lambda: Float[Array, "1 Dy Dy"] = field(init=False)
+    ln_det_Sigma: Float[Array, "1"] = field(init=False)
+    
     def __post_init__(
         self,
     ):
         if self.R != 1:
             raise NotImplementedError("So far only R=1 is supported.")
-        if self.Dy < self.Du:
-            raise NotImplementedError(
-                "There must be less vectors U than dimensionality of Y."
-            )
-        self.sigma2_x = self.sigma_x**2
-        self._setup_noise_diagonal_functions()
+        try:
+            assert self.Dy <= self.Da
+        except AssertionError:
+            raise NotImplementedError("A must have at least as many rows as columns.")
+        try:
+            assert self.Dk <= self.Da
+        except AssertionError:
+            raise NotImplementedError("Diagonal matrix can have at most as many entries as A has columns.")
+        
+        self.Sigma = jnp.einsum("abc,adc->abd", self.A, self.A)
+        self.Lambda, self.ln_det_Sigma = invert_matrix(self.Sigma)
+        
+    @abstractmethod
+    def link_function(self, h: Float[Array, "..."]) -> Float[Array, "..."]:
+        """Link function for the heteroscedastic noise."""
+        pass
 
     @property
     def R(self) -> int:
@@ -747,22 +763,22 @@ class HCCovGaussianConditional(conditional.ConditionalGaussianPDF):
         return self.M.shape[2]
 
     @property
-    def Du(self) -> int:
+    def Da(self) -> int:
         r"""Number of orthonormal low rank vectors :math:`U`."""
-        return self.beta.shape[0]
+        return self.A.shape[2]
+    
+    @property
+    def Dk(self) -> int:
+        r"""Number of orthonormal low rank vectors :math:`U`."""
+        return self.W.shape[0]
+    
+    def linear_layer(self, x: Float[Array, "N Dx"]) -> Float[Array, "N Dk"]:
+        """Linear layer of the argument of heteroscedastic link function.
 
-    def _setup_noise_diagonal_functions(self):
-        r"""Create the functions, that later need to be integrated over, i.e.
-
-        .. math::
-
-            \exp(h_i(z)) \text{ and } \exp(-h_i(z))
+        :return: :math:`w^\top x + w_0`.
         """
-        nu = self.W[:, 1:]
-        ln_beta = self.W[:, 0]
-        self.exp_h_plus = factor.LinearFactor(nu=nu, ln_beta=ln_beta)
-        self.exp_h_minus = factor.LinearFactor(nu=-nu, ln_beta=-ln_beta)
-
+        return jnp.einsum("ab,cb->ca", self.W[:,1:], x) + self.W[:,0][None]
+    
     def get_conditional_cov(
         self, x: Float[Array, "N Dx"], invert: bool = False
     ) -> Union[
@@ -773,9 +789,9 @@ class HCCovGaussianConditional(conditional.ConditionalGaussianPDF):
 
         .. math::
 
-            \Sigma_y(X=x) = \sigma_x^2 I + \sum_i U_i D_i(x) U_i^\top,
+            \Sigma_y(X=x) = \Sigma + A_{:k} D(x) A_{:k}^\top,
 
-        with :math:`D_i(x) = 2 * \beta_i * \cosh(h_i(x))` and :math:`h_i(x) = w_i^\top x + b_i`.
+        with :math:`D_i(x) = \cosh(h_i(x))-1` and :math:`h_i(x) = w_i^\top x + b_i`.
 
         Args:
             x: Instances, the :math:`\mu` should be conditioned on.
@@ -783,26 +799,22 @@ class HCCovGaussianConditional(conditional.ConditionalGaussianPDF):
         Returns:
             Conditional covariance.
         """
-        D_x = self.beta[None] * (self.exp_h_plus(x) + self.exp_h_minus(x)).T
-        Sigma_0 = self.sigma2_x * jnp.eye(self.Dy)
-        print(D_x.shape, self.U.shape)
-        Sigma_y_x = Sigma_0[None] + jnp.einsum(
-            "adb,cb->acd", jnp.einsum("ab,cb->cab", self.U, D_x), self.U
+        h = self.linear_layer(x)
+        D_x = self.link_function(h) 
+        Sigma = self.Sigma + jnp.einsum(
+            "abc,dc->abd", jnp.einsum("ab,cb->cab", self.A[0,:,:self.Dk], D_x), self.A[0,:,:self.Dk]
         )
         if invert:
-            G_x = D_x / (self.sigma2_x + D_x)
-            print(G_x.shape, self.U.shape)
-            Sigma_y_x_inv = jnp.eye(self.Dy)[None] - jnp.einsum(
-                "adb,cb->acd", jnp.einsum("ab,cb->cab", self.U, G_x), self.U
+            G_x = D_x / (1 + D_x) # [N x Dk]
+            A_inv = jnp.einsum('ab,bc->ac', self.Lambda[0], self.A[0,:,:self.Dk]) # [Dy x Dk] # [N x Dy x Dk]
+            Lambda = self.Lambda - jnp.einsum(
+                "abc,dc->abd", jnp.einsum("ab,cb->cab", A_inv, G_x), A_inv
             )
-            Sigma_y_x_inv /= self.sigma2_x
-            ln_det_Sigma_y_x = (self.Dy - self.Du) * jnp.log(self.sigma2_x) + jnp.sum(
-                jnp.log(self.sigma2_x + D_x), axis=1
-            )
-            return Sigma_y_x, Sigma_y_x_inv, ln_det_Sigma_y_x
+            ln_det_Sigma_y_x = self.ln_det_Sigma + jnp.sum(jnp.log(1 + D_x), axis=1)
+            return Sigma, Lambda, ln_det_Sigma_y_x
         else:
-            return Sigma_y_x
-
+            return Sigma
+        
     def condition_on_x(self, x: Float[Array, "N Dx"], **kwargs) -> pdf.GaussianPDF:
         r"""Get Gaussian Density conditioned on :math:`X=x`.
 
@@ -823,7 +835,7 @@ class HCCovGaussianConditional(conditional.ConditionalGaussianPDF):
         )
         # Sigma_new = self.get_conditional_cov(x)
         # return pdf.GaussianPDF(Sigma=Sigma_new, mu=mu_new)
-
+        
     def set_y(self, y: Float[Array, "R Dy"], **kwargs):
         r"""Not valid function for this model class.
 
@@ -835,8 +847,8 @@ class HCCovGaussianConditional(conditional.ConditionalGaussianPDF):
             AttributeError: Raised because doesn't :math:`p(Y|X)` is not
                 a ConjugateFactor for :math:`X`.
         """
-        raise AttributeError("HCCovGaussianConditional doesn't have function set_y.")
-
+        raise AttributeError("HeteroscedasticConditional doesn't have function set_y.")
+    
     def integrate_Sigma_x(self, p_x: pdf.GaussianPDF) -> Float[Array, "Dy Dy"]:
         r"""Integrate covariance with respect to :math:`p(X)`.
 
@@ -850,18 +862,33 @@ class HCCovGaussianConditional(conditional.ConditionalGaussianPDF):
         Returns:
             Integrated covariance matrix.
         """
-        # int 2 cosh(h(z)) dphi(z)
-        D_int = (
-            p_x.multiply(self.exp_h_plus).integrate()
-            + p_x.multiply(self.exp_h_minus).integrate()
-        )
-        D_int = self.beta[None] * D_int.reshape((p_x.R, self.Du))
-        Sigma_int = self.sigma2_x * jnp.eye(self.Dy)[None] + jnp.einsum(
-            "abc,dc->abd", self.U[None] * D_int[:, None], self.U
-        )
+        # int f(h(z)) dphi(z)
+        D_int = self._integrate_noise_diagonal(p_x)
+        # rotation_mat_int = jnp.eye(self.Dy)[None] + jnp.einsum(
+        #    "abc,dc->abd", self.U[None] * D_int[:, None], self.U
+        # )
+        Sigma_int = self.Sigma + jnp.einsum(
+            "ab,cb->ac", jnp.einsum("ab,b->ab", self.A[0,:,:self.Dk], D_int), self.A[0,:,:self.Dk]
+        )[None]
         Sigma_int = 0.5 * (Sigma_int + jnp.swapaxes(Sigma_int, -2, -1))
         return Sigma_int
+    
+    @abstractmethod
+    def _integrate_noise_diagonal(self, p_x: pdf.GaussianPDF) -> Float[Array, "N Dk"]:
+        r"""Integrate the noise diagonal with respect to :math:`p(X)`.
 
+        .. math::
+
+            \int D(x) p(x) {\rm d}x.
+
+        Args:
+            p_x: The density the noise diagonal is integrated with.
+
+        Returns:
+            Integrated noise diagonal.
+        """
+        pass
+    
     def get_expected_moments(
         self, p_x: pdf.GaussianPDF
     ) -> Tuple[Float[Array, "R Dy"], Float[Array, "1 Dy Dy"]]:
@@ -886,9 +913,9 @@ class HCCovGaussianConditional(conditional.ConditionalGaussianPDF):
             "(Ax+a)(Bx+b)'", A_mat=self.M, a_vec=self.b, B_mat=self.M, b_vec=self.b
         )
         Sigma_y = Eyy - mu_y[:, None] * mu_y[:, :, None]
-        # Sigma_y = .5 * (Sigma_y + Sigma_y.T)
+        Sigma_y = 0.5 * (Sigma_y + jnp.swapaxes(Sigma_y, axis1=-1, axis2=-2))
         return mu_y, Sigma_y
-
+    
     def get_expected_cross_terms(self, p_x: pdf.GaussianPDF) -> Float[Array, "R Dx Dy"]:
         r"""Compute :math:`\mathbb{E}[yx^\top] = \int\int yx^\top p(y|x)p(x) {\rm d}y{\rm d}x = \int (M x + b)x^\top p(x) {\rm d}x`.
 
@@ -969,6 +996,7 @@ class HCCovGaussianConditional(conditional.ConditionalGaussianPDF):
         M_new = jnp.einsum("abc,abd->acd", cov_yx, Lambda_y)
         b_new = mu_x - jnp.einsum("abc,ac->ab", M_new, mu_y)
         Sigma_new = p_x.Sigma - jnp.einsum("abc,acd->abd", M_new, cov_yx)
+        # Sigma_new = 0.5 * (Sigma_new + jnp.swapaxes(Sigma_new, -1, -2))
         cond_p_xy = conditional.ConditionalGaussianPDF(
             M=M_new,
             b=b_new,
@@ -1006,271 +1034,212 @@ class HCCovGaussianConditional(conditional.ConditionalGaussianPDF):
         mu_y, Sigma_y = self.get_expected_moments(p_x)
         p_y = pdf.GaussianPDF(Sigma=Sigma_y, mu=mu_y)
         return p_y
+    
+    def integrate_log_conditional_y(self, p_x: pdf.GaussianPDF, y: Float[Array, "N Dy"], **kwargs) -> Float[Array, "N"]:
+        lb_quadratic_term = self.get_lb_quadratic_term(p_x, y)
+        lb_log_det = self.get_lb_log_det(p_x)
+        lb_log_p_y = -.5 * (lb_quadratic_term + lb_log_det + self.Dy * jnp.log(2. * jnp.pi))[0]
+        return lb_log_p_y
+    
+    @staticmethod
+    def _get_omega_dagger(p_x: pdf.GaussianPDF, W_i: Float[Array, "Dx+1"]) -> Float[Array, "R"]:
+        b = W_i[None,:1]
+        w = W_i[None,1:]
+        omega_dagger = jnp.sqrt(p_x.integrate("(Ax+a)'(Bx+b)", A_mat=w, a_vec=b, B_mat=w, b_vec=b))
+        return omega_dagger
 
-    def integrate_log_conditional_y(
-        self, p_x: pdf.GaussianPDF, y: Float[Array, "N Dy"], **kwargs
-    ) -> Float[Array, "N"]:
-        r"""Compute the expectation over the log conditional, but just over :math:`X`. I.e. it returns
-
-        .. math::
-
-            f(Y) = \int \log(p(Y|X))p(X){\rm d}X.
-
-        Args:
-            p_x: Density over :math:`X`.
-
-        Raises:
-            NotImplementedError: Only implemented for R=1.
-
-        Returns:
-            The integral evaluated for of :math:`Y=y`.
-        """
-        vec = y - self.b
-        E_epsilon2 = p_x.integrate(
-            "(Ax+a)'(Bx+b)", A_mat=-self.M, a_vec=vec, B_mat=-self.M, b_vec=vec
-        )
-
-        def scan_body_function(carry, args_i):
-            W_i, u_i, beta_i = args_i
-            omega_star_i, omega_dagger_i, _ = lax.stop_gradient(
-                self._get_omega_star_i(W_i, u_i, beta_i, p_x, y)
-            )
-            uRu_i, log_lb_sum_i = self._get_lb_i(
-                W_i, u_i, beta_i, omega_star_i, omega_dagger_i, p_x, y
-            )
-            result = (uRu_i, log_lb_sum_i)
-            return carry, result
-
-        _, result = lax.scan(scan_body_function, None, (self.W, self.U.T, self.beta))
-        uRu, log_lb_sum = result
-        E_D_inv_epsilon2 = jnp.sum(uRu, axis=0)
-        E_ln_sigma2_f = jnp.sum(log_lb_sum, axis=0)
-        log_int_y = -0.5 * (E_epsilon2 - E_D_inv_epsilon2) / self.sigma_x**2
-        # determinant part
-        log_int_y = (
-            log_int_y
-            - 0.5 * E_ln_sigma2_f
-            + 0.5 * (self.Du - self.Dy) * jnp.log(self.sigma_x**2)
-            - 0.5 * self.Dy * jnp.log(2.0 * jnp.pi)
-        )
-        return log_int_y
-
-    def _get_lb_i(
-        self,
-        W_i: Float[Array, "Dx+1"],
-        u_i: Float[Array, "Dy"],
-        beta_i: Float[Array, "1"],
-        omega_star: Float[Array, "N"],
-        omega_dagger,
-        p_x: pdf.GaussianPDF,
-        y: Float[Array, "N Dy"],
-    ) -> Tuple[Float[Array, "N"], Float[Array, "N"]]:
-        # phi = pdf.GaussianPDF(**phi_dict)
-        # beta = self.beta[iu:iu + 1]
-        # Lower bound for \mathbb{E}[ln (sigma_x^2 + f(h))]
-        R = p_x.R
-        w_i = W_i[1:].reshape((1, -1))
-        v = jnp.tile(w_i, (R, 1))
-        b_i = W_i[:1]
-        u_i = u_i.reshape((-1, 1))
-        # uC = jnp.dot(u_i.T, -self.M[0])
-        # uy_d = jnp.dot(u_i.T, (y - self.b[0]).T)
-        # Lower bound for \mathbb{E}[ln (sigma_x^2 + f(h))]
-
-        Eh2 = p_x.integrate("(Ax+a)'(Bx+b)", A_mat=w_i, a_vec=b_i, B_mat=w_i, b_vec=b_i)
-        f_omega_dagger = self.f(omega_dagger, beta_i)
-        g_omega_dagger = self.g(omega_dagger, beta_i)
-        log_lb = jnp.log(self.sigma_x**2 + f_omega_dagger) + 0.5 * g_omega_dagger * (
-            Eh2 - omega_dagger**2
-        )
-        g_omega = self.g(omega_star, beta_i)
-        nu_plus = (1.0 - g_omega[:, None] * b_i) * w_i
-        nu_minus = (-1.0 - g_omega[:, None] * b_i) * w_i
-        ln_beta = (
-            -jnp.log(self.sigma_x**2 + self.f(omega_star, beta_i))
-            - 0.5 * g_omega * (b_i**2 - omega_star**2)
-            + jnp.log(beta_i)
-        )
-        ln_beta_plus = ln_beta + b_i
-        ln_beta_minus = ln_beta - b_i
-        # Create OneRankFactors
-        exp_factor_plus = factor.OneRankFactor(
-            v=v, g=g_omega, nu=nu_plus, ln_beta=ln_beta_plus
-        )
-        exp_factor_minus = factor.OneRankFactor(
-            v=v, g=g_omega, nu=nu_minus, ln_beta=ln_beta_minus
-        )
-        # Create the two measures
-        exp_phi_plus = p_x.hadamard(exp_factor_plus, update_full=True)
-        exp_phi_minus = p_x.hadamard(exp_factor_minus, update_full=True)
-        mat1 = -self.M[0]
-        vec1 = y - self.b[0]
-        R_plus = exp_phi_plus.integrate(
-            "(Ax+a)(Bx+b)'", A_mat=mat1, a_vec=vec1, B_mat=mat1, b_vec=vec1
-        )
-        R_minus = exp_phi_minus.integrate(
-            "(Ax+a)(Bx+b)'", A_mat=mat1, a_vec=vec1, B_mat=mat1, b_vec=vec1
-        )
-        R = R_plus + R_minus
-        R = R
-        # R = .5 * (R + R.T)
-        uRu = jnp.sum(u_i.T * jnp.einsum("abc, cb -> ab", R, u_i), axis=1)
-        log_lb_sum = log_lb
-        return uRu, log_lb_sum
-
-    def _get_omega_star_i(
-        self,
-        W_i: Float[Array, "Dy+1"],
-        u_i: Float[Array, "Dy"],
-        beta_i: Float[Array, "1"],
-        p_x: pdf.GaussianPDF,
-        y: Float[Array, "N"],
-        conv_crit: float = 1e-3,
-    ) -> Tuple[Float[Array, "N"], Int[Array, "_"]]:
-        R = p_x.R
-        w_i = W_i[1:].reshape((1, -1))
-        v = jnp.tile(w_i, (R, 1))
-        b_i = W_i[:1]
-        u_i = u_i[:].reshape((-1, 1))
-        uM = jnp.dot(u_i.T, -self.M[0])
-        uy_b = jnp.dot(u_i.T, (y - self.b[0]).T)
-        # Lower bound for \mathbb{E}[ln (sigma_x^2 + f(h))]
-        omega_dagger = jnp.sqrt(
-            p_x.integrate("(Ax+a)'(Bx+b)", A_mat=w_i, a_vec=b_i, B_mat=w_i, b_vec=b_i)
-        )
-        omega_star = 1e-15 * jnp.ones(R)
-        # omega_star = omega_star_init
-        omega_old = 10 * jnp.ones(R)
-
-        def body_fun(omegas):
-            omega_star, omega_old, num_iter = omegas
-            # From the lower bound term
-            g_omega = self.g(omega_star, beta_i)
-            nu_plus = (1.0 - g_omega[:, None] * b_i) * w_i
-            nu_minus = (-1.0 - g_omega[:, None] * b_i) * w_i
-            ln_beta = (
-                -jnp.log(self.sigma_x**2 + self.f(omega_star, beta_i))
-                - 0.5 * g_omega * (b_i**2 - omega_star**2)
-                + jnp.log(beta_i)
-            )
-            ln_beta_plus = ln_beta + b_i
-            ln_beta_minus = ln_beta - b_i
-            # Create OneRankFactors
-            exp_factor_plus = factor.OneRankFactor(
-                v=v, g=g_omega, nu=nu_plus, ln_beta=ln_beta_plus
-            )
-            exp_factor_minus = factor.OneRankFactor(
-                v=v, g=g_omega, nu=nu_minus, ln_beta=ln_beta_minus
-            )
-            # Create the two measures
-            exp_phi_plus = p_x.hadamard(exp_factor_plus, update_full=True)
-            exp_phi_minus = p_x.hadamard(exp_factor_minus, update_full=True)
-            # Fourth order integrals \mathbb{E}[h^2 (x-Cz-d)^2]
-            quart_int_plus = exp_phi_plus.integrate(
-                "(Ax+a)'(Bx+b)(Cx+c)'(Dx+d)",
-                A_mat=uM,
-                a_vec=uy_b.T,
-                B_mat=uM,
-                b_vec=uy_b.T,
-                C_mat=w_i,
-                c_vec=b_i,
-                D_mat=w_i,
-                d_vec=b_i,
-            )
-            quart_int_minus = exp_phi_minus.integrate(
-                "(Ax+a)'(Bx+b)(Cx+c)'(Dx+d)",
-                A_mat=uM,
-                a_vec=uy_b.T,
-                B_mat=uM,
-                b_vec=uy_b.T,
-                C_mat=w_i,
-                c_vec=b_i,
-                D_mat=w_i,
-                d_vec=b_i,
-            )
-            quart_int = quart_int_plus + quart_int_minus
-            # Second order integrals \mathbb{E}[(x-Cz-d)^2] Dims: [Du, Dx, Dx]
-            quad_int_plus = exp_phi_plus.integrate(
-                "(Ax+a)'(Bx+b)", A_mat=uM, a_vec=uy_b.T, B_mat=uM, b_vec=uy_b.T
-            )
-            quad_int_minus = exp_phi_minus.integrate(
-                "(Ax+a)'(Bx+b)", A_mat=uM, a_vec=uy_b.T, B_mat=uM, b_vec=uy_b.T
-            )
-            quad_int = quad_int_plus + quad_int_minus
-            omega_old = omega_star
-            omega_star = jnp.sqrt(jnp.abs(quart_int / quad_int))
-            num_iter = num_iter + 1
-            return omega_star, omega_old, num_iter
-
-        def cond_fun(omegas):
-            omega_star, omega_old, num_iter = omegas
-            # return lax.pmax(jnp.amax(jnp.abs(omega_star - omega_old)), 'i') > conv_crit
-            return jnp.logical_and(
-                jnp.amax(jnp.amax(jnp.abs(omega_star - omega_old) / omega_star))
-                > conv_crit,
-                num_iter < 100,
-            )
-
-        num_iter = 0
-        init_val = (omega_star, omega_old, num_iter)
-        omega_star, omega_old, num_iter = lax.while_loop(cond_fun, body_fun, init_val)
-        indices_non_converged = (
-            jnp.abs(omega_star - omega_old) / omega_star
-        ) > conv_crit
-
-        return omega_star, omega_dagger, indices_non_converged
-
-    def f(self, h: Float[Array, "N"], beta: float) -> Float[Array, "N"]:
-        """Compute the function
+    @abstractmethod
+    def k_func(self, p_x: pdf.GaussianPDF, W_i:Float[Array, "Dx+1"], omega_dagger: Float[Array, "R"]) -> Float[Array, "R"]:
+        pass
+    
+    def get_lb_log_det(self, p_x: pdf.GaussianPDF) -> Float[Array, "N"]:
+        omega_dagger = lax.stop_gradient(vmap(lambda W: self._get_omega_dagger(p_x=p_x, W_i=W), in_axes=(0,))(self.W))
+        k_omega = vmap(lambda W, omega: self.k_func(p_x=p_x, W_i=W, omega_dagger=omega))(self.W, omega_dagger)
+        print(k_omega.shape)
+        lower_bound_log_det = self.ln_det_Sigma + jnp.sum(k_omega, axis=0)
+        return lower_bound_log_det
+    
+    def get_lb_quadratic_term(self, p_x: pdf.GaussianPDF, y: Float[Array, "N Dy"]):
+        projected_M = jnp.einsum('acb,acd->abd', self.Lambda, self.M)
+        projected_yb = jnp.einsum('acb,ac->ab', self.Lambda, y - self.b)
+        homoscedastic_term = p_x.integrate("(Ax+a)'(Bx+b)", A_mat=-projected_M, a_vec=projected_yb, B_mat=-self.M, b_vec=y - self.b)
+        A_inv = jnp.einsum('abc,acd->abd', self.Lambda, self.A[:,:,:self.Dk])[0]
+        get_lb_heteroscedastic_term = jnp.sum(vmap(lambda W, A_inv: self.get_lb_heteroscedastic_term_i(p_x, y, W, A_inv))(self.W, A_inv.T), axis=0)
+        return homoscedastic_term - get_lb_heteroscedastic_term
+    
+    def get_lb_heteroscedastic_term_i(self, p_x: pdf.GaussianPDF, y: Float[Array, "N Dy"], 
+                                      W_i: Float[Array, "Dx+1"], a_i: Float[Array, "Dy"]):
+        omega_star = lax.stop_gradient(self._get_omega_star(p_x=p_x, y=y, W_i=W_i, a_i=a_i))
+        # Quadratic integral
+        return self._lower_bound_integrals(p_x, y, W_i, a_i, omega_star)
+    
+    @abstractmethod
+    def _lower_bound_integrals(self, p_x: measure.GaussianMeasure, y: Float[Array, "N Dy"], 
+                              W_i: Float[Array, "Dx+1"], a_i: Float[Array, "Dy"], omega_star: Float[Array, "N"], compute_fourth_order: bool=False) -> Float[Array, "N"]:
+        pass                           
+    
+    def _get_omega_star(self, p_x: pdf.GaussianPDF, y: jnp.ndarray, W_i: Float[Array, "Dx+1"], a_i: Float[Array, "Dy"]):
+        omega_star = self._get_omega_dagger(p_x=p_x, W_i=W_i)
+        omega_dagger = omega_star + 1.
+        cond_func = lambda val: jnp.max(jnp.abs(val[0] - val[1])) > 1e-5
+        body_func = lambda val: (self._update_omega_star(p_x=p_x, y=y, W_i=W_i, a_i=a_i, omega_star=val[0]), val[0])
+        omega_star, _ = lax.while_loop(cond_func, body_func, (omega_star, omega_dagger))
+        return omega_star
+    
+    def _update_omega_star(self, p_x: pdf.GaussianPDF, y: Float[Array, "N Dy"], W_i: Float[Array, "Dx+1"], a_i: Float[Array, "Dy"], omega_star: Float[Array, "N"]) -> Float[Array, "N"]:      
+        quadratic_integral, quartic_integral = self._lower_bound_integrals(p_x=p_x, y=y, W_i=W_i, a_i=a_i, omega_star=omega_star, compute_fourth_order=True)
+        omega_star = jnp.sqrt(quartic_integral / quadratic_integral)[0]
+        return omega_star
+    
+@dataclass(kw_only=True)
+class HeteroscedasticExpConditional(HeteroscedasticConditional):
+    M: Float[Array, "1 Dy Dx"]
+    b: Float[Array, "1 Dy"]
+    A: Float[Array, "1 Dy Da"]
+    W: Float[Array, "Dk Dx+1"]
+    Sigma: Float[Array, "1 Dy Dy"] = field(default=None)
+    Lambda: Float[Array, "1 Dy Dy"] = field(init=False)
+    ln_det_Sigma: Float[Array, "1"] = field(init=False)
+    
+    def link_function(self, h: Float[Array, "..."]) -> Float[Array, "..."]:
+        """Link function for the heteroscedastic noise."""
+        return jnp.exp(h)
+    
+        
+    def _integrate_noise_diagonal(self, p_x: pdf.GaussianPDF) -> Float[Array, "N Dk"]:
+        r"""Integrate the noise diagonal with respect to :math:`p(X)`.
 
         .. math::
 
-        f(h) = 2 * \beta * \cosh(h)
+            \int D(x) p(x) {\rm d}x.
 
         Args:
-            h: Activation functions.
-            beta: Scaling factor.
+            p_x: The density the noise diagonal is integrated with.
 
         Returns:
-            Evaluated functions
+            Integrated noise diagonal.
         """
-        return 2 * beta * jnp.cosh(h)
+        # int f(h(z)) dphi(z)
+        nu = self.W[:, 1:]
+        ln_beta = self.W[:, 0]
+        exp_h = factor.LinearFactor(nu=nu, ln_beta=ln_beta)
+        D_int = p_x.multiply(exp_h, update_full=True).integrate()
+        return D_int
+    
+    @staticmethod
+    def _get_omega_dagger(p_x: pdf.GaussianPDF, W_i: Float[Array, "Dx+1"]) -> Float[Array, "R"]:
+        b = W_i[None,:1]
+        w = W_i[None,1:]
+        omega_dagger = jnp.sqrt(p_x.integrate("(Ax+a)'(Bx+b)", A_mat=w, a_vec=b, B_mat=w, b_vec=b))
+        return omega_dagger
 
-    def f_prime(self, h: Float[Array, "N"], beta: float) -> Float[Array, "N"]:
-        """Computes the derivative of f
+    def k_func(self, p_x: pdf.GaussianPDF, W_i:Float[Array, "Dx+1"], omega_dagger: Float[Array, "R"]) -> Float[Array, "R"]:
+        b = W_i[None,:1]
+        w = W_i[None,1:]
+        Eh2 = p_x.integrate("(Ax+a)'(Bx+b)", A_mat=w, a_vec=b, B_mat=w, b_vec=b)
+        Eh = p_x.integrate("(Ax+a)", A_mat=w, a_vec=b)[:,0]
+        fomega = jnp.log(jnp.cosh(omega_dagger / 2.)) + jnp.log(2.)
+        fprime_omega = .5 * jnp.tanh(omega_dagger / 2.)
+        return .5 * Eh + fomega + .5 * fprime_omega  / omega_dagger * (Eh2 - omega_dagger ** 2)
+    
+    
+    def _lower_bound_integrals(self, p_x: measure.GaussianMeasure, y: Float[Array, "N Dy"], 
+                              W_i: Float[Array, "Dx+1"], a_i: Float[Array, "Dy"], omega_star: Float[Array, "N"], compute_fourth_order: bool=False) -> Float[Array, "N"]:
+        b = W_i[None,:1]
+        w = W_i[None,1:]
+        fomega = jnp.log(jnp.cosh(.5 * omega_star)) + jnp.log(2.)
+        fprime_omega = .5 * jnp.tanh(.5 * omega_star)
+        g_1 = fprime_omega / omega_star
+        nu_1 = -((fprime_omega / omega_star)[:,None] * b - .5) * w
+        ln_beta_1 = - fomega - .5 * fprime_omega / omega_star * (b ** 2 - omega_star ** 2) + .5 * b 
+        lb_px_measure = p_x.hadamard(factor.OneRankFactor(v=w, g=g_1, nu=nu_1, ln_beta=ln_beta_1), update_full=True)
+        a_projected_M = jnp.einsum('ab,cad->cbd', a_i[:,None], self.M)
+        a_projected_yb = jnp.einsum('ab,ca->cb', a_i[:,None], y - self.b)
+        quadratic_integral = lb_px_measure.integrate("(Ax+a)'(Bx+b)", A_mat=-a_projected_M, a_vec=a_projected_yb, B_mat=-a_projected_M, b_vec=a_projected_yb)
+        if compute_fourth_order:
+            quartic_integral = lb_px_measure.integrate("(Ax+a)'(Bx+b)(Cx+c)'(Dx+d)", A_mat=w, a_vec=b, B_mat=w, b_vec=b, C_mat=-a_projected_M, c_vec=a_projected_yb, D_mat=-a_projected_M, d_vec=a_projected_yb)
+            return quadratic_integral, quartic_integral
+        else:
+            return quadratic_integral
+    
+@dataclass(kw_only=True)
+class HeteroscedasticCoshM1Conditional(HeteroscedasticConditional):
+    M: Float[Array, "1 Dy Dx"]
+    b: Float[Array, "1 Dy"]
+    A: Float[Array, "1 Dy Da"]
+    W: Float[Array, "Dk Dx+1"]
+    Sigma: Float[Array, "1 Dy Dy"] = field(default=None)
+    Lambda: Float[Array, "1 Dy Dy"] = field(init=False)
+    ln_det_Sigma: Float[Array, "1"] = field(init=False)
+    
+    def link_function(self, h: Float[Array, "..."]) -> Float[Array, "..."]:
+        """Link function for the heteroscedastic noise."""
+        return jnp.cosh(h) - 1.
+              
+    def _integrate_noise_diagonal(self, p_x: pdf.GaussianPDF) -> Float[Array, "N Dk"]:
+        r"""Integrate the noise diagonal with respect to :math:`p(X)`.
 
         .. math::
 
-            f^\prime(h) = 2 * \beta * \sinh(h)
+            \int D(x) p(x) {\rm d}x.
 
         Args:
-            h: Activation functions.
-            beta: Scaling factor.
+            p_x: The density the noise diagonal is integrated with.
 
         Returns:
-            Evaluated derivative functions.
+            Integrated noise diagonal.
         """
-        return 2 * beta * jnp.sinh(h)
-
-    def g(self, omega: Float[Array, "N"], beta: float) -> Float[Array, "N"]:
-        r"""Computes the function
-
-        .. math::
-
-            g(\omega) = f'(\omega) / (sigma_x^2 + f(\omega)) / |\omega|
-
-            for the variational bound
-
-        Args:
-            omega: Free variational parameter.
-            beta: Scaling factor.
-            sigma_x: Noise parameter.
-
-        Returns:
-            Evaluated function.
-        """
-        return (
-            self.f_prime(omega, beta)
-            / (self.sigma_x**2 + self.f(omega, beta))
-            / jnp.abs(omega)
+        # int f(h(z)) dphi(z)
+        nu = self.W[:, 1:]
+        ln_beta = self.W[:, 0]
+        exp_h_plus = factor.LinearFactor(nu=nu, ln_beta=ln_beta - jnp.log(2))
+        exp_h_minus = factor.LinearFactor(nu=-nu, ln_beta=-ln_beta - jnp.log(2))
+        D_int = (
+        p_x.multiply(exp_h_plus, update_full=True).integrate()
+        + p_x.multiply(exp_h_minus, update_full=True).integrate()
+        - 1.0
         )
+        return D_int
+    
+    @staticmethod
+    def _get_omega_dagger(p_x: pdf.GaussianPDF, W_i: Float[Array, "Dx+1"]) -> Float[Array, "R"]:
+        b = W_i[None,:1]
+        w = W_i[None,1:]
+        omega_dagger = jnp.sqrt(p_x.integrate("(Ax+a)'(Bx+b)", A_mat=w, a_vec=b, B_mat=w, b_vec=b))
+        return omega_dagger
+
+    def k_func(self, p_x: pdf.GaussianPDF, W_i:Float[Array, "Dx+1"], omega_dagger: Float[Array, "R"]) -> Float[Array, "R"]:
+        b = W_i[None,:1]
+        w = W_i[None,1:]
+        Eh2 = p_x.integrate("(Ax+a)'(Bx+b)", A_mat=w, a_vec=b, B_mat=w, b_vec=b)
+        f_omega = jnp.log(jnp.cosh(omega_dagger))
+        fprime_omega = jnp.tanh(omega_dagger)
+        return f_omega + .5 * fprime_omega  / omega_dagger * (Eh2 - omega_dagger ** 2)
+    
+    def _lower_bound_integrals(self, p_x: measure.GaussianMeasure, y: Float[Array, "N Dy"], 
+                            W_i: Float[Array, "Dx+1"], a_i: Float[Array, "Dy"], omega_star: Float[Array, "N"], compute_fourth_order: bool=False) -> Float[Array, "N"]:
+        b = W_i[None,:1]
+        w = W_i[None,1:]
+        f_omega = jnp.log(jnp.cosh(omega_star))
+        fprime_omega = .5 * jnp.tanh(omega_star) / omega_star
+        g_1 = 2. * fprime_omega
+        nu_1 =  - 2. * fprime_omega[:,None] * b * w
+        ln_beta_1 = - f_omega - fprime_omega * (b ** 2 - omega_star ** 2)
+        lb_px_measure = p_x.hadamard(factor.OneRankFactor(v=jnp.tile(w, (omega_star.shape[0], 1)), g=g_1, nu=nu_1, ln_beta=ln_beta_1), update_full=True)
+        a_projected_M = jnp.einsum('ab,cad->cbd', a_i[:,None], self.M)
+        a_projected_yb = jnp.einsum('ab,ca->cb', a_i[:,None], y - self.b)  
+        exp_h_plus = factor.LinearFactor(nu=w, ln_beta=b - jnp.log(2))
+        phi_plus = lb_px_measure.hadamard(exp_h_plus, update_full=True)
+        quadratic_plus = phi_plus.integrate("(Ax+a)'(Bx+b)", A_mat=-a_projected_M, a_vec=a_projected_yb, B_mat=-a_projected_M, b_vec=a_projected_yb)
+        exp_h_minus = factor.LinearFactor(nu=-w, ln_beta=- b - jnp.log(2))
+        phi_minus = lb_px_measure.hadamard(exp_h_minus, update_full=True)
+        quadratic_minus = phi_minus.integrate("(Ax+a)'(Bx+b)", A_mat=-a_projected_M, a_vec=a_projected_yb, B_mat=-a_projected_M, b_vec=a_projected_yb)
+        quadratic_1 = lb_px_measure.integrate("(Ax+a)'(Bx+b)", A_mat=-a_projected_M, a_vec=a_projected_yb, B_mat=-a_projected_M, b_vec=a_projected_yb) 
+        quadratic_integral = quadratic_plus + quadratic_minus - quadratic_1
+        if compute_fourth_order:
+            quartic_integral = phi_plus.integrate("(Ax+a)'(Bx+b)(Cx+c)'(Dx+d)", A_mat=w, a_vec=b, B_mat=w, b_vec=b, C_mat=-a_projected_M, c_vec=a_projected_yb, D_mat=-a_projected_M, d_vec=a_projected_yb)
+            quartic_integral += phi_minus.integrate("(Ax+a)'(Bx+b)(Cx+c)'(Dx+d)", A_mat=w, a_vec=b, B_mat=w, b_vec=b, C_mat=-a_projected_M, c_vec=a_projected_yb, D_mat=-a_projected_M, d_vec=a_projected_yb)
+            quartic_integral -= lb_px_measure.integrate("(Ax+a)'(Bx+b)(Cx+c)'(Dx+d)", A_mat=w, a_vec=b, B_mat=w, b_vec=b, C_mat=-a_projected_M, c_vec=a_projected_yb, D_mat=-a_projected_M, d_vec=a_projected_yb)
+            return quadratic_integral, quartic_integral
+        else:
+            return quadratic_integral       

--- a/gaussian_toolbox/experimental/misc.py
+++ b/gaussian_toolbox/experimental/misc.py
@@ -1,0 +1,7 @@
+from jax import numpy as jnp
+from jax.scipy.special import gammaln
+from jaxtyping import Array, Float, Integer
+from typing import Union
+
+def binom(k: Union[int, Integer[Array, ""]], i: Union[int, Integer[Array, ""]]) -> Union[int, Integer[Array, ""]]:
+  return jnp.array(jnp.round(jnp.exp(gammaln(k + 1) - gammaln(i + 1) - gammaln(k - i + 1))), dtype=int)

--- a/gaussian_toolbox/experimental/misc.py
+++ b/gaussian_toolbox/experimental/misc.py
@@ -2,6 +2,17 @@ from jax import numpy as jnp
 from jax.scipy.special import gammaln
 from jaxtyping import Array, Float, Integer
 from typing import Union
+from jax.scipy.stats import norm
 
 def binom(k: Union[int, Integer[Array, ""]], i: Union[int, Integer[Array, ""]]) -> Union[int, Integer[Array, ""]]:
-  return jnp.array(jnp.round(jnp.exp(gammaln(k + 1) - gammaln(i + 1) - gammaln(k - i + 1))), dtype=int)
+    return jnp.array(jnp.round(jnp.exp(gammaln(k + 1) - gammaln(i + 1) - gammaln(k - i + 1))), dtype=int)
+
+def normal_pdf(x: Float[Array, ""]) -> Float[Array, ""]:
+    return norm.pdf(x)
+    #return norm.pdf(jnp.where(jnp.isfinite(x), x, 1e15))
+
+def normal_cdf(x: Float[Array, ""]) -> Float[Array, ""]:
+    y = norm.cdf(x)
+    return jnp.where(y < 1., y, 1. + norm.logcdf(x))
+    #y = norm.cdf(jnp.where(jnp.isfinite(x), x, jnp.sign(x) * 1e15))
+    

--- a/gaussian_toolbox/experimental/truncated_measure.py
+++ b/gaussian_toolbox/experimental/truncated_measure.py
@@ -1,0 +1,258 @@
+from jax import numpy as jnp
+from jax.lax import scan
+from jax.scipy.stats import norm
+from ..utils.dataclass import dataclass
+from dataclasses import field
+from jaxtyping import Array, Float
+from typing import Any, Callable, Tuple, Union, Dict
+from gaussian_toolbox import pdf, measure
+from .misc import binom
+
+
+@dataclass(kw_only=True)
+class TruncatedGaussianMeasure:
+    """Truncated Gaussian measure.
+    
+    Args:
+        measure: Gaussian measure.
+        lower_limit: Lower limit of truncation.
+        upper_limit: Upper limit of truncation.
+    """
+    measure: measure.GaussianMeasure
+    lower_limit: Float[Array, "R 1"] = field(default=None)
+    upper_limit: Float[Array, "R 1"] = field(default=None)
+    density: pdf.GaussianPDF = field(init=False)
+    constant: Float[Array, "R"] = field(init=False)
+    alpha: Float[Array, "R 1"] = field(init=False)
+    beta: Float[Array, "R 1"] = field(init=False)
+    
+    def __post_init__(self):
+        self._check_limits()
+        assert self.measure.D == 1, "TruncatedGaussianMeasure only supports 1D measures"
+        self.density = self.measure.get_density()
+        self.constant = self.measure.integrate()
+        self.alpha = (self.lower_limit - self.density.mu) / jnp.sqrt(self.density.Sigma[..., 0])
+        self.beta = (self.upper_limit - self.density.mu) / jnp.sqrt(self.density.Sigma[..., 0])
+        
+    def _check_limits(self):
+        """Check that lower_limit and upper_limit are valid.
+        """
+        if self.lower_limit is None and self.upper_limit is None:
+            raise ValueError("At least one of lower_limit and upper_limit must be specified.")
+        elif self.lower_limit is None:
+            self.lower_limit = -jnp.inf * jnp.ones((self.R, self.D))
+        elif self.upper_limit is None:
+            self.upper_limit = jnp.inf * jnp.ones((self.R, self.D))
+            
+        self.lower_limit = self.lower_limit * jnp.ones((self.R, self.D))
+        self.upper_limit = self.upper_limit * jnp.ones((self.R, self.D))
+        assert jnp.all(self.lower_limit < self.upper_limit), "lower_limit must be smaller than upper_limit"
+        
+    @property
+    def R(self) -> int:
+        """Number of factors (leading dimension)."""
+        return self.measure.Lambda.shape[0]
+
+    @property
+    def D(self) -> int:
+        r"""Dimensionality of :math:`X`."""
+        return self.measure.Lambda.shape[1]
+        
+    def __call__(self, x: Float[Array, "N 1"], element_wise: bool = False) -> Union[Float[Array, "R N"], Float[Array, "R"]]:
+        """Evaluate the measure at x.
+
+        :raises ValueError: If x has wrong shape.
+        :return: The measure evaluated at x.
+        """
+        if element_wise:
+            if self.R != x.shape[0]:
+                raise ValueError("Leading dimension of x must equal R.")
+            in_limits = jnp.all(jnp.logical_and(jnp.greater_equal(x, self.lower_limit), jnp.less_equal(x, self.upper_limit)), axis=-1)
+        else:
+            in_limits = jnp.all(jnp.logical_and(jnp.greater_equal(x[None], self.lower_limit[:,None]), 
+                                                jnp.less_equal(x[None], self.upper_limit[:,None])), axis=-1)
+        return self.measure(x, element_wise=element_wise) * in_limits
+    
+    def integrate(self, expr: str = "1", **kwargs) -> Float[Array, "R ..."]:
+        r"""Integrate the indicated expression with respect to the truncated Gaussian measure.
+
+        E.g. expr="x**2" means that :math:`\int X^2 u(X){\rm d}X` is computed, and :math:`A` and a can be provided.
+
+        :param expr: Indicates the expression that should be integrated. Check measure's integration dict.
+        :return: The integral result.
+        """
+        return self.integration_dict[expr](**kwargs)
+        
+    @property
+    def integration_dict(self) -> Dict:
+        return {
+            "1": self.integral,
+            "x": self.integrate_x,
+            "x**2": self.integrate_x_pow_2,
+            "x**k": self.integrate_x_pow_k,
+        }
+        
+    def _expectation_integral(self) -> Float[Array, "R"]:
+        """Compute the normalizing constant of the integral of the truncated Gaussian measure.
+
+        Returns: 
+            The normalizing constant of the measure.
+        """
+        return jnp.squeeze(norm.cdf(self.beta) - norm.cdf(self.alpha), axis=-1)
+    
+    def integral(self) -> Float[Array, "R"]:
+        """Compute the integral of the truncated Gaussian measure.
+        
+        Returns:
+            The integral of the measure.
+        """
+        return self._expectation_integral() * self.constant
+    
+    def _expectation_x(self) -> Float[Array, "R 1"]:
+        """Compute the expectation of x under the truncated Gaussian density corresponding to the measure.
+        
+        Returns:
+            The expectation of x.
+        """
+        Z = self._expectation_integral()[:,None]
+        return self.density.mu + (norm.pdf(self.alpha) - norm.pdf(self.beta)) / Z * jnp.sqrt(self.density.Sigma[..., 0])
+        
+    def integrate_x(self) -> Float[Array, "R 1"]:
+        """Compute the integral of x under the truncated Gaussian measure.
+
+        Returns:
+            The integral of x.
+        """
+        return self._expectation_x() * self.integral()[:,None]
+    
+    def _get_variance(self) -> Float[Array, "R 1"]:
+        """Compute the variance of x under the truncated Gaussian density corresponding to the measure.
+
+        Returns:
+            The variance of x.
+        """
+        Z = self._expectation_integral()[:, None]
+        beta_pdf = jnp.where(jnp.isfinite(self.beta), self.beta * norm.pdf(self.beta), 0)
+        alpha_pdf = jnp.where(jnp.isfinite(self.alpha), self.alpha * norm.pdf(self.alpha), 0)
+        variance = self.density.Sigma[..., 0] * (1 - 
+                                              (beta_pdf - alpha_pdf) / Z
+                                              - (norm.pdf(self.alpha) - norm.pdf(self.beta))**2 / Z**2)
+        return variance
+    
+    def integrate_x_pow_2(self) -> Float[Array, "R 1"]:
+        """Compute the integral of x^2 under the truncated Gaussian measure.
+
+        Returns:
+            The integral of x^2.
+        """
+        variance = self._get_variance()
+        mu = self._expectation_x()
+        return (variance + mu ** 2) * self.integral()[:,None]
+    
+    def _get_moment(self, order: int, return_all: bool=False) -> Union[Float[Array, "R order+1"], Float[Array, "R order+1"]]:
+        """Compute the moment of order `order` under the truncated Gaussian density corresponding to the measure.
+
+        Returns:
+            The moment of `order`.
+        """
+        denominator = norm.cdf(self.beta[:,0]) - norm.cdf(self.alpha[:,0])
+        
+        def scan_function(carry, k):
+            L2, L1 = carry
+            beta_pdf = jnp.where(jnp.isfinite(self.beta[:,0]), self.beta[:,0] ** (k - 1) * norm.pdf(self.beta[:,0]), 0)
+            alpha_pdf = jnp.where(jnp.isfinite(self.alpha[:,0]), self.alpha[:,0]  ** (k - 1) * norm.pdf(self.alpha[:,0]), 0)
+            L_new = - (beta_pdf - alpha_pdf) / denominator + (k - 1) * L2
+            print(alpha_pdf.shape, beta_pdf.shape,L_new.shape, L2.shape, L1.shape)
+            return (L1, L_new), L_new
+        
+        L0, L1 = jnp.ones((self.R,)), - (norm.pdf(self.beta[:,0]) - norm.pdf(self.alpha[:,0])) / denominator
+        Ls = scan(scan_function, (L0, L1), jnp.arange(2, order + 1))[1]
+        Ls = jnp.concatenate([L0[None], L1[None], Ls], axis=0)
+        k_range = jnp.arange(0, order + 1)[:,None]
+        if return_all:
+            moments = jnp.cumsum(binom(order, k_range) * jnp.sqrt(self.density.Sigma[:,:,0].T) ** k_range * self.density.mu.T ** (order - k_range) * Ls, axis=0)
+        else:
+            moments = jnp.sum(binom(order, k_range) * jnp.sqrt(self.density.Sigma[:,:,0].T) ** k_range * self.density.mu.T ** (order - k_range) * Ls, axis=0)           
+        return moments
+    
+    def integrate_x_pow_k(self, k: int) -> Float[Array, "R 1"]:
+        """Compute the integral of x^k under the truncated Gaussian measure.
+        
+        Args:
+            k: The order of the moment to compute.
+            
+        Returns:
+            The integral of x^k.
+        """
+        print(self._get_moment(k).shape, self.integral().shape)
+        return self._get_moment(k)[:,None] * self.integral()[:,None]
+    
+    def get_density(self) -> "TruncatedGaussianPDF":
+        """Return the truncated Gaussian density corresponding to the measure.
+
+        Returns:
+            The truncated Gaussian density corresponding to the measure.
+        """
+        return TruncatedGaussianPDF(measure=self.density, lower_limit=self.lower_limit, upper_limit=self.upper_limit)
+    
+@dataclass(kw_only=True)
+class TruncatedGaussianPDF(TruncatedGaussianMeasure):
+    """Normalized Truncated Gaussian density.
+    
+    Args:
+        measure: Gaussian measure.
+        lower_limit: Lower limit of truncation.
+        upper_limit: Upper limit of truncation.
+    """
+    measure: measure.GaussianMeasure
+    lower_limit: Float[Array, "R 1"] = field(default=None)
+    upper_limit: Float[Array, "R 1"] = field(default=None)
+    density: pdf.GaussianPDF = field(init=False)
+    constant: Float[Array, "R"] = field(init=False)
+    alpha: Float[Array, "R 1"] = field(init=False)
+    beta: Float[Array, "R 1"] = field(init=False)
+    
+    def __post_init__(self):
+        super(TruncatedGaussianPDF, self).__post_init__()
+        self.constant = self._expectation_integral()
+        self.constant = 1. / self.constant
+        
+    def __call__(self, x: Float[Array, "N 1"], element_wise: bool = False) -> Union[Float[Array, "R N"], Float[Array, "R"]]:
+        """Compute the value of the density at x.
+        
+        Args:
+            x: The point at which to compute the density.
+            element_wise: Whether to return the density at each point of x or the density at x.
+
+        Returns:
+            The value of the density at x.
+        """
+        if element_wise:
+            return super(TruncatedGaussianPDF, self).__call__(x, element_wise=element_wise) * self.constant
+        else:
+            return super(TruncatedGaussianPDF, self).__call__(x, element_wise=element_wise) * self.constant[:,None]
+        
+    def get_mean(self) -> Float[Array, "R 1"]:
+        """Compute the mean of the density.
+
+        Returns:
+            The mean of the density.
+        """
+        return self._expectation_x()
+    
+    def get_variance(self) -> Float[Array, "R 1"]:
+        """Compute the variance of the density.
+
+        Returns:
+            The variance of the density.
+        """
+        variance = self._get_variance()
+        return variance
+    
+    def get_std(self) -> Float[Array, "R 1"]:
+        """Compute the standard deviation of the density.
+
+        Returns:
+            The standard deviation of the density.
+        """
+        return jnp.sqrt(self.get_variance())

--- a/gaussian_toolbox/experimental/truncated_measure.py
+++ b/gaussian_toolbox/experimental/truncated_measure.py
@@ -1,23 +1,25 @@
+__all__ = ["TruncatedGaussianMeasure", "TruncatedGaussianPDF"]
 from jax import numpy as jnp
+from jax.experimental import checkify
 from jax.lax import scan
-from jax.scipy.stats import norm
 from ..utils.dataclass import dataclass
 from dataclasses import field
 from jaxtyping import Array, Float
 from typing import Any, Callable, Tuple, Union, Dict
 from gaussian_toolbox import pdf, measure
-from .misc import binom
+from .misc import binom, normal_pdf, normal_cdf
 
 
 @dataclass(kw_only=True)
 class TruncatedGaussianMeasure:
     """Truncated Gaussian measure.
-    
+
     Args:
         measure: Gaussian measure.
         lower_limit: Lower limit of truncation.
         upper_limit: Upper limit of truncation.
     """
+
     measure: measure.GaussianMeasure
     lower_limit: Float[Array, "R 1"] = field(default=None)
     upper_limit: Float[Array, "R 1"] = field(default=None)
@@ -25,29 +27,48 @@ class TruncatedGaussianMeasure:
     constant: Float[Array, "R"] = field(init=False)
     alpha: Float[Array, "R 1"] = field(init=False)
     beta: Float[Array, "R 1"] = field(init=False)
-    
+
     def __post_init__(self):
         self._check_limits()
         assert self.measure.D == 1, "TruncatedGaussianMeasure only supports 1D measures"
-        self.density = self.measure.get_density()
+        if not isinstance(self.measure, pdf.GaussianPDF):
+            self.density = self.measure.get_density()
+        else:
+            self.density = self.measure
         self.constant = self.measure.integrate()
-        self.alpha = (self.lower_limit - self.density.mu) / jnp.sqrt(self.density.Sigma[..., 0])
-        self.beta = (self.upper_limit - self.density.mu) / jnp.sqrt(self.density.Sigma[..., 0])
-        
+        self.alpha = jnp.where(
+            jnp.isfinite(self.lower_limit),
+            (
+                jnp.where(jnp.isfinite(self.lower_limit), self.lower_limit, 0)
+                - self.density.mu
+            )
+            * jnp.sqrt(self.density.Lambda[:, :, 0]),
+            self.lower_limit,
+        )
+        self.beta = jnp.where(
+            jnp.isfinite(self.upper_limit),
+            (
+                jnp.where(jnp.isfinite(self.upper_limit), self.upper_limit, 0)
+                - self.density.mu
+            )
+            * jnp.sqrt(self.density.Lambda[:, :, 0]),
+            self.upper_limit,
+        )
+
     def _check_limits(self):
-        """Check that lower_limit and upper_limit are valid.
-        """
+        """Check that lower_limit and upper_limit are valid."""
         if self.lower_limit is None and self.upper_limit is None:
-            raise ValueError("At least one of lower_limit and upper_limit must be specified.")
+            raise ValueError(
+                "At least one of lower_limit and upper_limit must be specified."
+            )
         elif self.lower_limit is None:
             self.lower_limit = -jnp.inf * jnp.ones((self.R, self.D))
         elif self.upper_limit is None:
             self.upper_limit = jnp.inf * jnp.ones((self.R, self.D))
-            
+        # TODO: Find a way to check that lower_limit < upper_limit
         self.lower_limit = self.lower_limit * jnp.ones((self.R, self.D))
         self.upper_limit = self.upper_limit * jnp.ones((self.R, self.D))
-        assert jnp.all(self.lower_limit < self.upper_limit), "lower_limit must be smaller than upper_limit"
-        
+
     @property
     def R(self) -> int:
         """Number of factors (leading dimension)."""
@@ -57,8 +78,10 @@ class TruncatedGaussianMeasure:
     def D(self) -> int:
         r"""Dimensionality of :math:`X`."""
         return self.measure.Lambda.shape[1]
-        
-    def __call__(self, x: Float[Array, "N 1"], element_wise: bool = False) -> Union[Float[Array, "R N"], Float[Array, "R"]]:
+
+    def __call__(
+        self, x: Float[Array, "N 1"], element_wise: bool = False
+    ) -> Union[Float[Array, "R N"], Float[Array, "R"]]:
         """Evaluate the measure at x.
 
         :raises ValueError: If x has wrong shape.
@@ -67,12 +90,23 @@ class TruncatedGaussianMeasure:
         if element_wise:
             if self.R != x.shape[0]:
                 raise ValueError("Leading dimension of x must equal R.")
-            in_limits = jnp.all(jnp.logical_and(jnp.greater_equal(x, self.lower_limit), jnp.less_equal(x, self.upper_limit)), axis=-1)
+            in_limits = jnp.all(
+                jnp.logical_and(
+                    jnp.greater_equal(x, self.lower_limit),
+                    jnp.less_equal(x, self.upper_limit),
+                ),
+                axis=-1,
+            )
         else:
-            in_limits = jnp.all(jnp.logical_and(jnp.greater_equal(x[None], self.lower_limit[:,None]), 
-                                                jnp.less_equal(x[None], self.upper_limit[:,None])), axis=-1)
+            in_limits = jnp.all(
+                jnp.logical_and(
+                    jnp.greater_equal(x[None], self.lower_limit[:, None]),
+                    jnp.less_equal(x[None], self.upper_limit[:, None]),
+                ),
+                axis=-1,
+            )
         return self.measure(x, element_wise=element_wise) * in_limits
-    
+
     def integrate(self, expr: str = "1", **kwargs) -> Float[Array, "R ..."]:
         r"""Integrate the indicated expression with respect to the truncated Gaussian measure.
 
@@ -82,7 +116,7 @@ class TruncatedGaussianMeasure:
         :return: The integral result.
         """
         return self.integration_dict[expr](**kwargs)
-        
+
     @property
     def integration_dict(self) -> Dict:
         return {
@@ -91,40 +125,45 @@ class TruncatedGaussianMeasure:
             "x**2": self.integrate_x_pow_2,
             "x**k": self.integrate_x_pow_k,
         }
-        
+
     def _expectation_integral(self) -> Float[Array, "R"]:
         """Compute the normalizing constant of the integral of the truncated Gaussian measure.
 
-        Returns: 
+        Returns:
             The normalizing constant of the measure.
         """
-        return jnp.squeeze(norm.cdf(self.beta) - norm.cdf(self.alpha), axis=-1)
-    
+        return jnp.squeeze(normal_cdf(self.beta) - normal_cdf(self.alpha), axis=-1)
+
     def integral(self) -> Float[Array, "R"]:
         """Compute the integral of the truncated Gaussian measure.
-        
+
         Returns:
             The integral of the measure.
         """
         return self._expectation_integral() * self.constant
-    
+
     def _expectation_x(self) -> Float[Array, "R 1"]:
         """Compute the expectation of x under the truncated Gaussian density corresponding to the measure.
-        
+
         Returns:
             The expectation of x.
         """
-        Z = self._expectation_integral()[:,None]
-        return self.density.mu + (norm.pdf(self.alpha) - norm.pdf(self.beta)) / Z * jnp.sqrt(self.density.Sigma[..., 0])
-        
+        Z = self._expectation_integral()[:, None]
+        Z = jnp.where(Z != 0, Z, 1.0)
+        mean = self.density.mu + (
+            normal_pdf(self.alpha) - normal_pdf(self.beta)
+        ) / Z * jnp.sqrt(self.density.Sigma[..., 0])
+        mean = jnp.where(Z != 0, mean, 0.0)
+        return mean
+
     def integrate_x(self) -> Float[Array, "R 1"]:
         """Compute the integral of x under the truncated Gaussian measure.
 
         Returns:
             The integral of x.
         """
-        return self._expectation_x() * self.integral()[:,None]
-    
+        return self._expectation_x() * self.integral()[:, None]
+
     def _get_variance(self) -> Float[Array, "R 1"]:
         """Compute the variance of x under the truncated Gaussian density corresponding to the measure.
 
@@ -132,13 +171,21 @@ class TruncatedGaussianMeasure:
             The variance of x.
         """
         Z = self._expectation_integral()[:, None]
-        beta_pdf = jnp.where(jnp.isfinite(self.beta), self.beta * norm.pdf(self.beta), 0)
-        alpha_pdf = jnp.where(jnp.isfinite(self.alpha), self.alpha * norm.pdf(self.alpha), 0)
-        variance = self.density.Sigma[..., 0] * (1 - 
-                                              (beta_pdf - alpha_pdf) / Z
-                                              - (norm.pdf(self.alpha) - norm.pdf(self.beta))**2 / Z**2)
+        Z = jnp.where(Z != 0, Z, 1.0)
+        beta_pdf = jnp.where(
+            jnp.isfinite(self.upper_limit), self.beta, 0.0
+        ) * normal_pdf(self.beta)
+        alpha_pdf = jnp.where(
+            jnp.isfinite(self.lower_limit), self.alpha, 0.0
+        ) * normal_pdf(self.alpha)
+        variance = self.density.Sigma[..., 0] * (
+            1
+            - (beta_pdf - alpha_pdf) / Z
+            - (normal_pdf(self.alpha) - normal_pdf(self.beta)) ** 2 / Z**2
+        )
+        variance = jnp.where(Z != 0, variance, 0.0)
         return variance
-    
+
     def integrate_x_pow_2(self) -> Float[Array, "R 1"]:
         """Compute the integral of x^2 under the truncated Gaussian measure.
 
@@ -147,63 +194,94 @@ class TruncatedGaussianMeasure:
         """
         variance = self._get_variance()
         mu = self._expectation_x()
-        return (variance + mu ** 2) * self.integral()[:,None]
-    
-    def _get_moment(self, order: int, return_all: bool=False) -> Union[Float[Array, "R order+1"], Float[Array, "R order+1"]]:
+        return (variance + mu**2) * self.integral()[:, None]
+
+    def _get_moment(
+        self, order: int, return_all: bool = False
+    ) -> Union[Float[Array, "R order+1"], Float[Array, "R order+1"]]:
         """Compute the moment of order `order` under the truncated Gaussian density corresponding to the measure.
 
         Returns:
             The moment of `order`.
         """
-        denominator = norm.cdf(self.beta[:,0]) - norm.cdf(self.alpha[:,0])
-        
+        denominator = normal_cdf(self.beta[:, 0]) - normal_cdf(self.alpha[:, 0])
+        denominator = jnp.where(denominator != 0, denominator, 1.0)
+
         def scan_function(carry, k):
             L2, L1 = carry
-            beta_pdf = jnp.where(jnp.isfinite(self.beta[:,0]), self.beta[:,0] ** (k - 1) * norm.pdf(self.beta[:,0]), 0)
-            alpha_pdf = jnp.where(jnp.isfinite(self.alpha[:,0]), self.alpha[:,0]  ** (k - 1) * norm.pdf(self.alpha[:,0]), 0)
-            L_new = - (beta_pdf - alpha_pdf) / denominator + (k - 1) * L2
-            print(alpha_pdf.shape, beta_pdf.shape,L_new.shape, L2.shape, L1.shape)
+            beta_pdf = jnp.where(
+                jnp.isfinite(self.beta[:, 0]),
+                self.beta[:, 0] ** (k - 1) * normal_pdf(self.beta[:, 0]),
+                0,
+            )
+            alpha_pdf = jnp.where(
+                jnp.isfinite(self.alpha[:, 0]),
+                self.alpha[:, 0] ** (k - 1) * normal_pdf(self.alpha[:, 0]),
+                0,
+            )
+            L_new = -(beta_pdf - alpha_pdf) / denominator + (k - 1) * L2
             return (L1, L_new), L_new
-        
-        L0, L1 = jnp.ones((self.R,)), - (norm.pdf(self.beta[:,0]) - norm.pdf(self.alpha[:,0])) / denominator
+
+        L0, L1 = (
+            jnp.ones((self.R,)),
+            -(normal_pdf(self.beta[:, 0]) - normal_pdf(self.alpha[:, 0])) / denominator,
+        )
         Ls = scan(scan_function, (L0, L1), jnp.arange(2, order + 1))[1]
         Ls = jnp.concatenate([L0[None], L1[None], Ls], axis=0)
-        k_range = jnp.arange(0, order + 1)[:,None]
+        k_range = jnp.arange(0, order + 1)[:, None]
         if return_all:
-            moments = jnp.cumsum(binom(order, k_range) * jnp.sqrt(self.density.Sigma[:,:,0].T) ** k_range * self.density.mu.T ** (order - k_range) * Ls, axis=0)
+            moments = jnp.cumsum(
+                binom(order, k_range)
+                * jnp.sqrt(self.density.Sigma[:, :, 0].T) ** k_range
+                * self.density.mu.T ** (order - k_range)
+                * Ls,
+                axis=0,
+            )
         else:
-            moments = jnp.sum(binom(order, k_range) * jnp.sqrt(self.density.Sigma[:,:,0].T) ** k_range * self.density.mu.T ** (order - k_range) * Ls, axis=0)           
+            moments = jnp.sum(
+                binom(order, k_range)
+                * jnp.sqrt(self.density.Sigma[:, :, 0].T) ** k_range
+                * self.density.mu.T ** (order - k_range)
+                * Ls,
+                axis=0,
+            )
+        moments = jnp.where(denominator != 0, moments, 0.0)
         return moments
-    
+
     def integrate_x_pow_k(self, k: int) -> Float[Array, "R 1"]:
         """Compute the integral of x^k under the truncated Gaussian measure.
-        
+
         Args:
             k: The order of the moment to compute.
-            
+
         Returns:
             The integral of x^k.
         """
-        print(self._get_moment(k).shape, self.integral().shape)
-        return self._get_moment(k)[:,None] * self.integral()[:,None]
-    
+        return self._get_moment(k)[:, None] * self.integral()[:, None]
+
     def get_density(self) -> "TruncatedGaussianPDF":
         """Return the truncated Gaussian density corresponding to the measure.
 
         Returns:
             The truncated Gaussian density corresponding to the measure.
         """
-        return TruncatedGaussianPDF(measure=self.density, lower_limit=self.lower_limit, upper_limit=self.upper_limit)
-    
+        return TruncatedGaussianPDF(
+            measure=self.density,
+            lower_limit=self.lower_limit,
+            upper_limit=self.upper_limit,
+        )
+
+
 @dataclass(kw_only=True)
 class TruncatedGaussianPDF(TruncatedGaussianMeasure):
     """Normalized Truncated Gaussian density.
-    
+
     Args:
         measure: Gaussian measure.
         lower_limit: Lower limit of truncation.
         upper_limit: Upper limit of truncation.
     """
+
     measure: measure.GaussianMeasure
     lower_limit: Float[Array, "R 1"] = field(default=None)
     upper_limit: Float[Array, "R 1"] = field(default=None)
@@ -211,15 +289,17 @@ class TruncatedGaussianPDF(TruncatedGaussianMeasure):
     constant: Float[Array, "R"] = field(init=False)
     alpha: Float[Array, "R 1"] = field(init=False)
     beta: Float[Array, "R 1"] = field(init=False)
-    
+
     def __post_init__(self):
         super(TruncatedGaussianPDF, self).__post_init__()
         self.constant = self._expectation_integral()
-        self.constant = 1. / self.constant
-        
-    def __call__(self, x: Float[Array, "N 1"], element_wise: bool = False) -> Union[Float[Array, "R N"], Float[Array, "R"]]:
+        self.constant = 1.0 / self.constant
+
+    def __call__(
+        self, x: Float[Array, "N 1"], element_wise: bool = False
+    ) -> Union[Float[Array, "R N"], Float[Array, "R"]]:
         """Compute the value of the density at x.
-        
+
         Args:
             x: The point at which to compute the density.
             element_wise: Whether to return the density at each point of x or the density at x.
@@ -228,10 +308,16 @@ class TruncatedGaussianPDF(TruncatedGaussianMeasure):
             The value of the density at x.
         """
         if element_wise:
-            return super(TruncatedGaussianPDF, self).__call__(x, element_wise=element_wise) * self.constant
+            return (
+                super(TruncatedGaussianPDF, self).__call__(x, element_wise=element_wise)
+                * self.constant
+            )
         else:
-            return super(TruncatedGaussianPDF, self).__call__(x, element_wise=element_wise) * self.constant[:,None]
-        
+            return (
+                super(TruncatedGaussianPDF, self).__call__(x, element_wise=element_wise)
+                * self.constant[:, None]
+            )
+
     def get_mean(self) -> Float[Array, "R 1"]:
         """Compute the mean of the density.
 
@@ -239,7 +325,7 @@ class TruncatedGaussianPDF(TruncatedGaussianMeasure):
             The mean of the density.
         """
         return self._expectation_x()
-    
+
     def get_variance(self) -> Float[Array, "R 1"]:
         """Compute the variance of the density.
 
@@ -248,7 +334,7 @@ class TruncatedGaussianPDF(TruncatedGaussianMeasure):
         """
         variance = self._get_variance()
         return variance
-    
+
     def get_std(self) -> Float[Array, "R 1"]:
         """Compute the standard deviation of the density.
 

--- a/gaussian_toolbox/factor.py
+++ b/gaussian_toolbox/factor.py
@@ -225,7 +225,7 @@ class ConjugateFactor:
             )
         return new_density_dict
 
-    def integrate_log_factor(self, phi_x: "GaussianMeasure") -> Float[Array, "R"]:
+    def _integrate_log_factor(self, phi_x: "GaussianMeasure") -> Float[Array, "R"]:
         """Integrate over the log factor with respect to a Gaussian measure.
 
         Args:

--- a/gaussian_toolbox/measure.py
+++ b/gaussian_toolbox/measure.py
@@ -1033,7 +1033,7 @@ class GaussianMeasure(factor.ConjugateFactor):
         Returns:
             The integral
         """
-        return factor.integrate_log_factor(self)
+        return factor._integrate_log_factor(self)
 
 
 @dataclass(kw_only=True)

--- a/gaussian_toolbox/pdf.py
+++ b/gaussian_toolbox/pdf.py
@@ -273,14 +273,11 @@ class GaussianDiagPDF(GaussianPDF, measure.GaussianDiagMeasure):
     lnZ: Float[Array, "R"] = field(default=None, init=False)
 
     def __post_init__(self):
-        self.Lambda, self.ln_det_Sigma = invert_diagonal(self.Sigma)
-        if self.nu is None:
-            self.nu = jnp.zeros((self.R, self.D))
-        if self.ln_beta is None:
-            self.ln_beta = jnp.zeros((self.R))
-        self.Sigma = self.Sigma
-        self.ln_det_Lambda = self.ln_det_Lambda
-        self.ln_det_Sigma = self.ln_det_Sigma
+        if self.Lambda is None:
+            self.Lambda, self.ln_det_Sigma = invert_diagonal(self.Sigma)
+        elif self.ln_det_Sigma is None:
+            self.ln_det_Sigma = jnp.linalg.slogdet(self.Sigma)[1]
+        self.nu = jnp.einsum("abc,ab->ac", self.Lambda, self.mu)
         self._prepare_integration()
         self.normalize()
 

--- a/gaussian_toolbox/pdf.py
+++ b/gaussian_toolbox/pdf.py
@@ -213,6 +213,26 @@ class GaussianPDF(measure.GaussianMeasure):
         return conditional.ConditionalGaussianPDF(
             M=M_x, b=b_x, Sigma=Sigma_x, Lambda=Lambda_x, ln_det_Sigma=-ln_det_Lambda_x
         )
+        
+    def get_density_of_linear_sum(self, W: Float[Array, "R Dsum D"], b: Float[Array, "R Dsum"] = None) -> "GaussianPDF":
+        """Returns density of linear sum of Gaussians.
+
+        Args:
+            W: Weight matrix.
+            b: Bias vector.
+
+        Returns:
+            Gaussian density of linear sum.
+        """
+        try:
+            assert W.shape[1] <= self.D
+        except AssertionError:
+            raise AssertionError(f"The number of sums must be <= {self.D}")
+        Sigma_sum = jnp.einsum("abc,acd,aed->abe", W, self.Sigma, W)
+        mu_sum = jnp.einsum("abc,ac->ab", W, self.mu)
+        if b is not None:
+            mu_sum += b
+        return GaussianPDF(Sigma=Sigma_sum, mu=mu_sum)
 
     def to_dict(self) -> Dict:
         """Write Gaussian into dict.
@@ -227,6 +247,7 @@ class GaussianPDF(measure.GaussianMeasure):
             "ln_det_Sigma": self.ln_det_Sigma,
         }
         return density_dict
+
 
 
 @dataclass(kw_only=True)

--- a/gaussian_toolbox/utils/dataclass.py
+++ b/gaussian_toolbox/utils/dataclass.py
@@ -88,7 +88,6 @@ def mappable_dataclass(cls):
 
 def dataclass(
     cls=None,
-    *,
     init=True,
     repr=True,  # pylint: disable=redefined-builtin
     eq=True,

--- a/gaussian_toolbox/utils/linalg.py
+++ b/gaussian_toolbox/utils/linalg.py
@@ -13,8 +13,6 @@ def invert_matrix(A: jnp.ndarray) -> Tuple[jnp.ndarray, jnp.ndarray]:
 
 
 def invert_diagonal(A: jnp.ndarray) -> Tuple[jnp.ndarray, jnp.ndarray]:
-    A_inv = jnp.concatenate(
-        [jnp.diag(mat)[None] for mat in 1.0 / A.diagonal(axis1=1, axis2=2)], axis=0
-    )
+    A_inv = 1.0 / A.diagonal(axis1=1, axis2=2)[:,:,None] * jnp.eye(A.shape[1])
     ln_det_A = jnp.sum(jnp.log(A.diagonal(axis1=1, axis2=2)), axis=1)
     return A_inv, ln_det_A

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,5 @@ pytest-cov
 scikit-learn
 tqdm
 git+https://github.com/deepmind/dm-haiku
+ipykernel
+pre-commit

--- a/tests/experimental/test_truncated_measure.py
+++ b/tests/experimental/test_truncated_measure.py
@@ -33,8 +33,9 @@ class TestTruncatedGaussianMeasure:
             with pytest.raises(ValueError):
                 tm, m = self.create_instance(R, lower, upper)
         elif lower_num >= upper_num:
-            with pytest.raises(AssertionError):
-                tm, m = self.create_instance(R, lower, upper)
+            pass
+        #    with pytest.raises(AssertionError):
+        #        tm, m = self.create_instance(R, lower, upper)
         else:
             tm, m = self.create_instance(R, lower, upper)
             if lower is None:

--- a/tests/experimental/test_truncated_measure.py
+++ b/tests/experimental/test_truncated_measure.py
@@ -1,0 +1,155 @@
+from gaussian_toolbox import pdf, measure
+from gaussian_toolbox.experimental import truncated_measure
+from scipy.stats import truncnorm
+import pytest
+from jax import numpy as jnp
+import numpy as np
+import jax
+from jax import config
+config.update("jax_enable_x64", True)
+np.random.seed(0)
+
+class TestTruncatedGaussianMeasure:
+    
+    def create_instance(self, R, lower, upper):
+        D = 1
+        Lambda = jnp.array(np.random.rand(R, D, D) + 1e-3)
+        nu = jnp.array(np.random.rand(R, D))
+        m = measure.GaussianMeasure(Lambda=Lambda, nu=nu)
+        tm = truncated_measure.TruncatedGaussianMeasure(measure=m, lower_limit=lower, upper_limit=upper)
+        return tm, m
+    
+    @pytest.mark.parametrize("R, lower, upper", [(1, -1, 2), (10, None, None), (2, 0, 1), (2, 0, -1), (2, 0, None), (2, 0, 0), (2, None, 0)])
+    def test_init(self, R, lower, upper):
+        if upper is None:
+            upper_num = jnp.inf
+        else:
+            upper_num = upper
+        if lower is None:
+            lower_num = -jnp.inf
+        else:
+            lower_num = lower
+        if upper is None and lower is None:
+            with pytest.raises(ValueError):
+                tm, m = self.create_instance(R, lower, upper)
+        elif lower_num >= upper_num:
+            with pytest.raises(AssertionError):
+                tm, m = self.create_instance(R, lower, upper)
+        else:
+            tm, m = self.create_instance(R, lower, upper)
+            if lower is None:
+                assert jnp.all(tm.lower_limit == -jnp.inf)
+            elif upper is None:
+                assert jnp.all(tm.upper_limit == jnp.inf)
+            assert tm.R == R
+            assert tm.D == 1
+            assert tm.lower_limit.shape == (R, 1)
+            assert tm.upper_limit.shape == (R, 1)
+            
+    @pytest.mark.parametrize("R, lower, upper", [(1, -1, 2), (2, 0, 1), (10, 0, None)])
+    def test_call(self, R, lower, upper):
+        tm, m = self.create_instance(R, lower, upper)
+        x = jnp.array(np.random.rand(R, 1))
+        if lower is None:
+            lower = -jnp.inf
+        elif upper is None:
+            upper = jnp.inf
+        in_limits = jnp.logical_and(jnp.greater_equal(x, lower), jnp.less_equal(x, upper))[:,0]
+        m_val = m(x, element_wise=True)
+        tm_val = tm(x, element_wise=True)
+        assert jnp.allclose(m_val[in_limits], tm_val[in_limits])
+        assert jnp.all(tm_val[~in_limits] == 0)
+        
+    @pytest.mark.parametrize("R, lower, upper", [(1, -1, 2), (2, 0, 1), (10, 0, None)])
+    def test_integrate(self, R, lower, upper):
+        for int_str in ["1", "x", "x**2"]:
+            tm, m = self.create_instance(R, lower, upper)
+            if int_str == "1":
+                assert jnp.all(jnp.less_equal(tm.integrate(int_str), m.integrate(int_str)))
+            if upper is not None:
+                tm1 = truncated_measure.TruncatedGaussianMeasure(measure=m, lower_limit=None, upper_limit=upper)
+                tm2 = truncated_measure.TruncatedGaussianMeasure(measure=m, lower_limit=upper, upper_limit=None)
+                if int_str == "x**2":
+                    assert jnp.allclose(tm1.integrate(int_str) + tm2.integrate(int_str), m.integrate("xx'")[:,0])
+                else:
+                    assert jnp.allclose(tm1.integrate(int_str) + tm2.integrate(int_str), m.integrate(int_str))
+                    
+    @pytest.mark.parametrize("R, lower, upper", [(1, -1, 2), (2, 0, 1), (10, 0, None)])
+    def test_get_density(self, R, lower, upper):
+        tm, m = self.create_instance(R, lower, upper)
+        tp = tm.get_density()
+        assert jnp.allclose(tp.integrate(), 1)
+        
+class TestTruncatedGaussianPDF(TestTruncatedGaussianMeasure):
+    
+    def create_instance(self, R, lower, upper):
+        D = 1
+        Lambda = jnp.array(np.random.rand(R, D, D) + 1e-3)
+        nu = jnp.array(np.random.rand(R, D))
+        m = measure.GaussianMeasure(Lambda=Lambda, nu=nu)
+        tm = truncated_measure.TruncatedGaussianPDF(measure=m, lower_limit=lower, upper_limit=upper)
+        tp = tm.get_density()
+        return tp, tp.density
+    
+    def _get_scipy_params(self, d, lower, upper):
+        loc, scale = d.mu[:,0], jnp.sqrt(d.Sigma[:,0,0])
+        a, b = (lower - loc) / scale, (upper - loc) / scale
+        return loc, scale, a, b
+    
+    @pytest.mark.parametrize("R, lower, upper", [(1, -1, 2), (2, 0, 1), (10, 0, None)])
+    def test_call(self, R, lower, upper):
+        tp, d = self.create_instance(R, lower, upper)
+        x = jnp.array(np.random.rand(100, 1))
+        if lower is None:
+            lower = -jnp.inf
+        elif upper is None:
+            upper = jnp.inf
+        in_limits = jnp.logical_and(jnp.greater_equal(x, lower), jnp.less_equal(x, upper))[:,0]
+        d_val = d(x)
+        tp_val = tp(x)
+        assert jnp.all(jnp.less_equal(d_val[:,in_limits], tp_val[:,in_limits]))
+        assert jnp.all(tp_val[:,~in_limits] == 0)
+    
+        loc, scale, a, b = self._get_scipy_params(d, lower, upper)
+        for r in range(R):
+            assert jnp.allclose(tp_val[r], truncnorm.pdf(x[:,0], a=a[r], b=b[r], loc=loc[r], scale=scale[r]), atol=1e-5)
+            
+    
+    @pytest.mark.parametrize("R, lower, upper", [(1, -1, 2), (2, 0, 1), (10, 0, None)])
+    def test_mean(self, R, lower, upper):
+        tp, d = self.create_instance(R, lower, upper)
+        if lower is None:
+            lower = -jnp.inf
+        elif upper is None:
+            upper = jnp.inf
+        mu = tp.get_mean()
+        loc, scale, a, b = self._get_scipy_params(d, lower, upper)
+        for r in range(R):
+            assert jnp.allclose(mu[r], truncnorm.mean(a=a[r], b=b[r], loc=loc[r], scale=scale[r]))
+            
+    @pytest.mark.parametrize("R, lower, upper", [(1, -1, 2), (2, 0, 1), (10, 0, None)])
+    def test_variance(self, R, lower, upper):
+        tp, d = self.create_instance(R, lower, upper)
+        if lower is None:
+            lower = -jnp.inf
+        elif upper is None:
+            upper = jnp.inf
+        sigma2 = tp.get_variance()
+        sigma = tp.get_std()
+        loc, scale, a, b = self._get_scipy_params(d, lower, upper)
+        for r in range(R):
+            assert jnp.allclose(sigma2[r], truncnorm.var(a=a[r], b=b[r], loc=loc[r], scale=scale[r]))
+            assert jnp.allclose(sigma[r], truncnorm.std(a=a[r], b=b[r], loc=loc[r], scale=scale[r]))
+            
+    @pytest.mark.parametrize("R, lower, upper", [(1, -1, 2), (2, 0, 1), (10, 0, None)])
+    def test_get_moments(self, R, lower, upper):
+        tp, d = self.create_instance(R, lower, upper)
+        if lower is None:
+            lower = -jnp.inf
+        elif upper is None:
+            upper = jnp.inf
+        loc, scale, a, b = self._get_scipy_params(d, lower, upper)
+        for order in range(1, 5):
+            moments = tp.integrate("x**k", k=order)
+            for r in range(R):
+                assert jnp.allclose(moments[r], truncnorm.moment(order , a=a[r], b=b[r], loc=loc[r], scale=scale[r]))

--- a/tests/test_approximate_conditional.py
+++ b/tests/test_approximate_conditional.py
@@ -9,6 +9,7 @@ import jax
 
 config.update("jax_enable_x64", True)
 import numpy as np
+np.random.seed(0)
 
 
 class TestLRBFGaussianConditional:

--- a/tests/test_approximate_conditional.py
+++ b/tests/test_approximate_conditional.py
@@ -221,6 +221,33 @@ class TestHeteroscedasticCoshM1Conditional(TestHeteroscedasticExpConditional):
         )  # jnp.tile(jnp.eye(Dx)[None], (R, 1, 1))#
         p_X = pdf.GaussianPDF(Sigma=Sigma_x, mu=mu_x)
         return cond, p_X
+    
+
+class TestHeteroscedasticReLUConditional(TestHeteroscedasticExpConditional):
+    @classmethod
+    def create_instance(self, R, Dx, Dy, Da, Dk):
+        C = jnp.array(np.random.randn(Dy, Dx))
+        C = C / jnp.sqrt(jnp.sum(C**2, axis=0))[None]
+        d = 1e-1 * jnp.array(np.random.randn(Dy))
+        rand_mat = np.random.rand(Dy, Dy) - 0.5
+        Q, _ = np.linalg.qr(rand_mat)
+        # self.U = jnp.eye(Dx)[:, :Du]
+        A = jnp.array(np.random.randn(Dy, Da))
+        W = 1e-1 * np.random.randn(Dk, Dx + 1)
+        W[:, 0] = 0
+        W = jnp.array(W)
+        cond = approximate_conditional.HeteroscedasticReLUConditional(
+            M=jnp.array([C]),
+            b=jnp.array([d]),
+            A=jnp.array([A]),
+            W=W,
+        )
+        mu_x = jnp.array(np.random.randn(R, Dx))
+        Sigma_x = self.get_pd_matrix(
+            R, Dx
+        )  # jnp.tile(jnp.eye(Dx)[None], (R, 1, 1))#
+        p_X = pdf.GaussianPDF(Sigma=Sigma_x, mu=mu_x)
+        return cond, p_X
 
 
 class TestHeteroscedasticHeavisideConditional:

--- a/tests/test_approximate_conditional.py
+++ b/tests/test_approximate_conditional.py
@@ -113,32 +113,27 @@ class TestLSEMGaussianConditional(TestLRBFGaussianConditional):
         return cond, p_X
 
 
-class TestHCCovGaussianConditional:
+class TestHeteroscedasticExpConditional:
     @classmethod
-    def create_instance(self, R, Dx, Dy, Du):
-        noise_x = 1.0
+    def create_instance(self, R, Dx, Dy, Da, Dk):
         C = jnp.array(np.random.randn(Dy, Dx))
         C = C / jnp.sqrt(jnp.sum(C**2, axis=0))[None]
         d = 1e-1 * jnp.array(np.random.randn(Dy))
         rand_mat = np.random.rand(Dy, Dy) - 0.5
         Q, _ = np.linalg.qr(rand_mat)
-        U = jnp.array(Q[:, :Du])
         # self.U = jnp.eye(Dx)[:, :Du]
-        W = 1e-1 * np.random.randn(Du, Dx + 1)
+        A = jnp.array(np.random.randn(Dy, Da))
+        W = 1e-1 * np.random.randn(Dk, Dx + 1)
         W[:, 0] = 0
         W = jnp.array(W)
-        beta = 0.5**2 * jnp.ones(Du)
-        sigma_x = jnp.array([noise_x])
-        cond = approximate_conditional.HCCovGaussianConditional(
+        cond = approximate_conditional.HeteroscedasticExpConditional(
             M=jnp.array([C]),
             b=jnp.array([d]),
-            sigma_x=sigma_x,
-            U=U,
+            A=jnp.array([A]),
             W=W,
-            beta=beta,
         )
         mu_x = jnp.array(np.random.randn(R, Dx))
-        Sigma_x = 10 * self.get_pd_matrix(
+        Sigma_x = self.get_pd_matrix(
             R, Dx
         )  # jnp.tile(jnp.eye(Dx)[None], (R, 1, 1))#
         p_X = pdf.GaussianPDF(Sigma=Sigma_x, mu=mu_x)
@@ -156,15 +151,15 @@ class TestHCCovGaussianConditional:
         return psd_mat
 
     @pytest.mark.parametrize(
-        "R, Dx, Dy, Du",
+        "R, Dx, Dy, Da, Dk",
         [
-            (1, 5, 2, 2),
-            (1, 10, 3, 1),
-            (1, 2, 5, 2),
+            (1, 5, 2, 3, 2),
+            (1, 10, 3, 4, 1),
+            (1, 2, 5, 5, 3),
         ],
     )
-    def test_affine_tranformations(self, R, Dx, Dy, Du):
-        cond, p_X = self.create_instance(R, Dx, Dy, Du)
+    def test_affine_tranformations(self, R, Dx, Dy, Da, Dk):
+        cond, p_X = self.create_instance(R, Dx, Dy, Da, Dk)
         p_YX = cond.affine_joint_transformation(p_X)
         p_Y = cond.affine_marginal_transformation(p_X)
         p_X_given_Y = cond.affine_conditional_transformation(p_X)
@@ -180,16 +175,48 @@ class TestHCCovGaussianConditional:
         assert jnp.allclose(p_X_given_Y.Lambda, p_X_given_Y2.Lambda)
 
     @pytest.mark.parametrize(
-        "R, Dx, Dy, Du",
-        [(1, 5, 1, 1), (1, 10, 1, 1), (1, 5, 2, 2), (1, 1, 10, 2)],
+        "R, Dx, Dy, Da, Dk",
+        [
+            (1, 5, 2, 3, 2),
+            (1, 10, 3, 4, 1),
+            (1, 2, 5, 5, 3),
+        ],
     )
-    def test_integrate_log_conditional_y(self, R, Dx, Dy, Du):
+    def test_integrate_log_conditional_y(self, R, Dx, Dy, Da, Dk):
         N = 1
         y = jnp.array(np.random.randn(N, Dy))
-        cond, p_X = self.create_instance(R, Dx, Dy, Du)
+        cond, p_X = self.create_instance(R, Dx, Dy, Da, Dk)
         integral_lb = cond.integrate_log_conditional_y(p_X, y=y)
         key = jax.random.PRNGKey(42)
         X_sample = p_X.sample(key, 100000)
         integral_sample_mean = jnp.mean(cond(X_sample[:, 0]).evaluate_ln(y), axis=0)
         integral_sample_std = jnp.std(cond(X_sample[:, 0]).evaluate_ln(y), axis=0)
-        assert jnp.all(integral_lb <= integral_sample_mean + 1e-2 * integral_sample_std)
+
+        assert jnp.all(integral_lb <= integral_sample_mean + .1 * integral_sample_std)
+        
+        
+class TestHeteroscedasticCoshM1Conditional(TestHeteroscedasticExpConditional):
+    @classmethod
+    def create_instance(self, R, Dx, Dy, Da, Dk):
+        C = jnp.array(np.random.randn(Dy, Dx))
+        C = C / jnp.sqrt(jnp.sum(C**2, axis=0))[None]
+        d = 1e-1 * jnp.array(np.random.randn(Dy))
+        rand_mat = np.random.rand(Dy, Dy) - 0.5
+        Q, _ = np.linalg.qr(rand_mat)
+        # self.U = jnp.eye(Dx)[:, :Du]
+        A = jnp.array(np.random.randn(Dy, Da))
+        W = 1e-1 * np.random.randn(Dk, Dx + 1)
+        W[:, 0] = 0
+        W = jnp.array(W)
+        cond = approximate_conditional.HeteroscedasticCoshM1Conditional(
+            M=jnp.array([C]),
+            b=jnp.array([d]),
+            A=jnp.array([A]),
+            W=W,
+        )
+        mu_x = jnp.array(np.random.randn(R, Dx))
+        Sigma_x = self.get_pd_matrix(
+            R, Dx
+        )  # jnp.tile(jnp.eye(Dx)[None], (R, 1, 1))#
+        p_X = pdf.GaussianPDF(Sigma=Sigma_x, mu=mu_x)
+        return cond, p_X

--- a/tests/test_approximate_conditional.py
+++ b/tests/test_approximate_conditional.py
@@ -221,3 +221,91 @@ class TestHeteroscedasticCoshM1Conditional(TestHeteroscedasticExpConditional):
         )  # jnp.tile(jnp.eye(Dx)[None], (R, 1, 1))#
         p_X = pdf.GaussianPDF(Sigma=Sigma_x, mu=mu_x)
         return cond, p_X
+
+
+class TestHeteroscedasticHeavisideConditional:
+    @classmethod
+    def create_instance(self, R, Dx, Dy, Da, Dk):
+        C = jnp.array(np.random.randn(Dy, Dx))
+        C = C / jnp.sqrt(jnp.sum(C**2, axis=0))[None]
+        d = 1e-1 * jnp.array(np.random.randn(Dy))
+        rand_mat = np.random.rand(Dy, Dy) - 0.5
+        Q, _ = np.linalg.qr(rand_mat)
+        # self.U = jnp.eye(Dx)[:, :Du]
+        A = jnp.array(np.random.randn(Dy, Da))
+        W = 1e-1 * np.random.randn(Dk, Dx + 1)
+        W[:, 0] = 0
+        W = jnp.array(W)
+        cond = approximate_conditional.HeteroscedasticHeavisideConditional(
+            M=jnp.array([C]),
+            b=jnp.array([d]),
+            A=jnp.array([A]),
+            W=W,
+        )
+        mu_x = jnp.array(np.random.randn(R, Dx))
+        Sigma_x = self.get_pd_matrix(
+            R, Dx
+        )  # jnp.tile(jnp.eye(Dx)[None], (R, 1, 1))#
+        p_X = pdf.GaussianPDF(Sigma=Sigma_x, mu=mu_x)
+        return cond, p_X
+
+    @staticmethod
+    def get_pd_matrix(R, D, eigen_mu=1):
+        # Q = jnp.array(np.random.randn((R, D, D))
+        # eig_vals = jnp.abs(eigen_mu + jnp.array(np.random.randn((R, D)))
+        # psd_mat = jnp.einsum("abc,abd->acd", Q * eig_vals[:, :, None], Q)
+        # psd_mat = 0.5 * (psd_mat + jnp.swapaxes(psd_mat, -1, -2))
+        A = jnp.array(np.random.rand(R, D, D))
+        psd_mat = jnp.einsum("abc,abd->acd", A, A)
+        psd_mat += jnp.eye(D)[None]
+        return psd_mat
+
+    @pytest.mark.parametrize(
+        "R, Dx, Dy, Da, Dk",
+        [
+            (1, 5, 2, 3, 2),
+            (1, 10, 3, 4, 1),
+            (1, 2, 5, 5, 3),
+        ],
+    )
+    def test_affine_tranformations(self, R, Dx, Dy, Da, Dk):
+        cond, p_X = self.create_instance(R, Dx, Dy, Da, Dk)
+        p_YX = cond.affine_joint_transformation(p_X)
+        p_Y = cond.affine_marginal_transformation(p_X)
+        p_X_given_Y = cond.affine_conditional_transformation(p_X)
+        dim_y = jnp.arange(Dx, Dy + Dx)
+        p_Y2 = p_YX.get_marginal(dim_y)
+        assert jnp.allclose(p_Y.mu, p_Y2.mu)
+        assert jnp.allclose(p_Y.Sigma, p_Y2.Sigma)
+        assert jnp.allclose(p_Y.Lambda, p_Y2.Lambda)
+        p_X_given_Y2 = p_YX.condition_on(dim_y)
+        assert jnp.allclose(p_X_given_Y.M, p_X_given_Y2.M)
+        assert jnp.allclose(p_X_given_Y.b, p_X_given_Y2.b)
+        assert jnp.allclose(p_X_given_Y.Sigma, p_X_given_Y2.Sigma)
+        assert jnp.allclose(p_X_given_Y.Lambda, p_X_given_Y2.Lambda)
+
+    @pytest.mark.parametrize(
+        "R, Dx, Dy, Da, Dk",
+        [
+            (1, 1, 2, 3, 2),
+            (1, 5, 2, 3, 3),
+            (1, 10, 3, 4, 4),
+            (1, 2, 5, 5, 1),
+        ],
+    )
+    def test_integrate_log_conditional_y(self, R, Dx, Dy, Da, Dk):
+        key = jax.random.PRNGKey(42)
+        key, subkey = jax.random.split(key)
+        N = 10
+        cond, p_X = self.create_instance(R, Dx, Dy, Da, Dk)
+        p_X_tiled = pdf.GaussianPDF(Sigma=jnp.tile(p_X.Sigma, (N,1,1)), mu=jnp.tile(p_X.mu, (N,1)))
+        p_Y = cond.affine_marginal_transformation(p_X)
+        y = p_Y.sample(subkey, N)[:,0]
+        print(y.shape, p_X_tiled.R)
+        integral_lb = cond.integrate_log_conditional_y(p_X_tiled, y=y)
+        key, subkey = jax.random.split(key)
+        X_sample = p_X.sample(subkey, 100000)
+        integral_sample_mean = jnp.mean(cond(X_sample[:, 0]).evaluate_ln(y), axis=0)
+        integral_sample_std = jnp.std(cond(X_sample[:, 0]).evaluate_ln(y), axis=0)
+        print(integral_lb, integral_sample_mean, integral_sample_std)
+        assert jnp.allclose(integral_lb, integral_sample_mean, atol=1e-1 * integral_sample_std)

--- a/tests/test_conditional.py
+++ b/tests/test_conditional.py
@@ -8,7 +8,7 @@ import jax
 
 config.update("jax_enable_x64", True)
 import numpy as np
-
+np.random.seed(0)
 
 class TestConditionalGaussianPDF:
     @classmethod

--- a/tests/test_factor.py
+++ b/tests/test_factor.py
@@ -1,8 +1,10 @@
 from gaussian_toolbox import factor, measure
 import pytest
 from jax import numpy as jnp
+from jax import config
+config.update("jax_enable_x64", True)
 import numpy as np
-
+np.random.seed(0)
 
 class TestConjugateFactor:
     def setup_class(self):

--- a/tests/test_factor.py
+++ b/tests/test_factor.py
@@ -76,7 +76,7 @@ class TestConjugateFactor:
         x_Lambda_x = jnp.einsum("adc,dc->ad", jnp.einsum("abc,dc->adb", f.Lambda, x), x)
         x_nu = jnp.dot(x, f.nu.T).T
         ln_eval_test = -0.5 * x_Lambda_x + x_nu + f.ln_beta[:, None]
-        assert jnp.alltrue(ln_eval == ln_eval_test)
+        assert jnp.allclose(ln_eval, ln_eval_test)
 
     @pytest.mark.parametrize("R, D", [(11, 5), (1, 5), (13, 1), (5, 5)])
     def test_product(self, R, D):
@@ -125,9 +125,9 @@ class TestConjugateFactor:
     def test_slice(self, R, D, idx):
         f = self.create_instance(R, D)
         f_new = f.slice(idx)
-        assert jnp.alltrue(f_new.Lambda == f.Lambda[idx])
-        assert jnp.alltrue(f_new.nu == f.nu[idx])
-        assert jnp.alltrue(f_new.ln_beta == f.ln_beta[idx])
+        assert jnp.allclose(f_new.Lambda, f.Lambda[idx])
+        assert jnp.allclose(f_new.nu, f.nu[idx])
+        assert jnp.allclose(f_new.ln_beta, f.ln_beta[idx])
 
 
 class TestOneRankFactor(TestConjugateFactor):
@@ -243,7 +243,7 @@ class TestOneRankFactor(TestConjugateFactor):
         x_Lambda_x = jnp.einsum("adc,dc->ad", jnp.einsum("abc,dc->adb", Lambda, x), x)
         x_nu = jnp.dot(x, f.nu.T).T
         ln_eval_test = -0.5 * x_Lambda_x + x_nu + f.ln_beta[:, None]
-        assert jnp.alltrue(ln_eval == ln_eval_test)
+        assert jnp.allclose(ln_eval, ln_eval_test)
 
     @pytest.mark.parametrize(
         "R, D, N", [(100, 5, 10), (1, 5, 10), (100, 1, 10), (100, 5, 1)]
@@ -257,7 +257,7 @@ class TestOneRankFactor(TestConjugateFactor):
         x_Lambda_x = jnp.einsum("adc,dc->ad", jnp.einsum("abc,dc->adb", Lambda, x), x)
         x_nu = jnp.dot(x, f.nu.T).T
         eval_test = jnp.exp(-0.5 * x_Lambda_x + x_nu + f.ln_beta[:, None])
-        assert jnp.alltrue(evaluate == eval_test)
+        assert jnp.allclose(evaluate, eval_test)
 
     @pytest.mark.parametrize("R, D", [(11, 5), (1, 5), (13, 1), (5, 5)])
     def test_product(self, R, D):
@@ -283,11 +283,11 @@ class TestOneRankFactor(TestConjugateFactor):
     def test_slice(self, R, D, idx):
         f = self.create_instance(R, D)
         f_new = f.slice(idx)
-        assert jnp.alltrue(f_new.v == f.v[idx])
-        assert jnp.alltrue(f_new.g == f.g[idx])
-        assert jnp.alltrue(f_new.Lambda == f.Lambda[idx])
-        assert jnp.alltrue(f_new.nu == f.nu[idx])
-        assert jnp.alltrue(f_new.ln_beta == f.ln_beta[idx])
+        assert jnp.allclose(f_new.v, f.v[idx])
+        assert jnp.allclose(f_new.g, f.g[idx])
+        assert jnp.allclose(f_new.Lambda, f.Lambda[idx])
+        assert jnp.allclose(f_new.nu, f.nu[idx])
+        assert jnp.allclose(f_new.ln_beta, f.ln_beta[idx])
 
 
 class TestLinearFactor(TestConjugateFactor):

--- a/tests/test_measure.py
+++ b/tests/test_measure.py
@@ -99,12 +99,12 @@ class TestGaussianMeasure(TestConjugateFactor):
         m = self.create_instance(R, D)
         m._prepare_integration()
         m_new = m.slice(idx)
-        assert jnp.alltrue(m_new.Lambda == m.Lambda[idx])
-        assert jnp.alltrue(m_new.nu == m.nu[idx])
-        assert jnp.alltrue(m_new.ln_beta == m.ln_beta[idx])
-        assert jnp.alltrue(m_new.Sigma == m.Sigma[idx])
-        assert jnp.alltrue(m_new.ln_det_Lambda == m.ln_det_Lambda[idx])
-        assert jnp.alltrue(m_new.ln_det_Sigma == m.ln_det_Sigma[idx])
+        assert jnp.allclose(m_new.Lambda, m.Lambda[idx])
+        assert jnp.allclose(m_new.nu, m.nu[idx])
+        assert jnp.allclose(m_new.ln_beta, m.ln_beta[idx])
+        assert jnp.allclose(m_new.Sigma, m.Sigma[idx])
+        assert jnp.allclose(m_new.ln_det_Lambda, m.ln_det_Lambda[idx])
+        assert jnp.allclose(m_new.ln_det_Sigma, m.ln_det_Sigma[idx])
 
     @pytest.mark.parametrize("R, D", [(11, 5), (1, 5), (13, 1), (5, 5)])
     def test_product(self, R, D):

--- a/tests/test_measure.py
+++ b/tests/test_measure.py
@@ -523,19 +523,19 @@ class TestGaussianMeasure(TestConjugateFactor):
             @jit
             def func(x):
                 x_vec = jnp.array(
-                    [
+                    [[
                         x,
-                    ]
+                    ]]
                 ).T
                 Ax_a = A_mat * x_vec + a_vec
                 Bx_b = B_mat * x_vec + b_vec
                 Cx_c = C_mat * x_vec + c_vec
                 integral = Ax_a * Bx_b * Cx_c * m(x_vec).T
-                return integral[:, r]
+                return integral[0, r]
 
             d = m.get_density()
             mu, var = d.mu, d.Sigma
-            integral_num = sc_integrate.quadrature(
+            integral_num = sc_integrate.quad(
                 func,
                 mu[r, 0] - 10 * jnp.sqrt(var[r, 0, 0]),
                 mu[r, 0] + 10 * jnp.sqrt(var[r, 0, 0]),
@@ -596,20 +596,20 @@ class TestGaussianMeasure(TestConjugateFactor):
             @jit
             def func(x):
                 x_vec = jnp.array(
-                    [
+                    [[
                         x,
-                    ]
+                    ]]
                 ).T
                 Ax_a = A_mat * x_vec + a_vec
                 Bx_b = B_mat * x_vec + b_vec
                 Cx_c = C_mat * x_vec + c_vec
                 Dx_d = D_mat * x_vec + d_vec
                 integral = Ax_a * Bx_b * Cx_c * Dx_d * m(x_vec).T
-                return integral[:, r]
+                return integral[0, r]
 
             d = m.get_density()
             mu, var = d.mu, d.Sigma
-            integral_num = sc_integrate.quadrature(
+            integral_num = sc_integrate.quad(
                 func,
                 mu[r, 0] - 10 * jnp.sqrt(var[r, 0, 0]),
                 mu[r, 0] + 10 * jnp.sqrt(var[r, 0, 0]),
@@ -703,16 +703,16 @@ class TestGaussianMeasure(TestConjugateFactor):
 
                 def func(x):
                     x_vec = jnp.array(
-                        [
+                        [[
                             x,
-                        ]
+                        ]]
                     ).T
                     integral = u.evaluate_ln(x_vec).T * m(x_vec).T
-                    return integral[:, r]
+                    return integral[0, r]
 
                 d = m.get_density()
                 mu, var = d.mu, d.Sigma
-                r_num = sc_integrate.quadrature(
+                r_num = sc_integrate.quad(
                     func,
                     mu[r, 0] - 10 * jnp.sqrt(var[r, 0, 0]),
                     mu[r, 0] + 10 * jnp.sqrt(var[r, 0, 0]),

--- a/tests/test_measure.py
+++ b/tests/test_measure.py
@@ -18,6 +18,7 @@ import jax
 config.update("jax_enable_x64", True)
 import numpy as np
 from scipy import integrate as sc_integrate
+np.random.seed(0)
 
 
 class TestGaussianMeasure(TestConjugateFactor):

--- a/tests/test_pdf.py
+++ b/tests/test_pdf.py
@@ -32,7 +32,7 @@ class TestGaussianPDF:
         assert d.Sigma.shape == (d.R, d.D, d.D)
         assert d.nu.shape == (d.R, d.D)
         assert d.ln_beta.shape == (d.R,)
-        assert jnp.alltrue(d.is_normalized())
+        assert jnp.all(d.is_normalized())
         assert jnp.allclose(d.integrate(), 1)
 
     @pytest.mark.parametrize("R, D", [(2, 5), (1, 5), (2, 1)])
@@ -99,8 +99,8 @@ class TestGaussianPDF:
         assert jnp.allclose(md.mu, d.mu[:, dim_x])
         idx = jnp.ix_(jnp.arange(R), dim_x, dim_x)
         assert jnp.allclose(md.Sigma, d.Sigma[idx])
-        assert jnp.alltrue(md.is_normalized())
-        assert jnp.alltrue(md.integrate() == 1)
+        assert jnp.all(md.is_normalized())
+        assert jnp.all(md.integrate() == 1)
 
     @pytest.mark.parametrize(
         "R, D, dim_y",
@@ -157,7 +157,7 @@ class TestGaussianPDF:
         assert np.allclose(d.kl_divergence(d), 0, atol=1e-6)
         d2 = self.create_instance(R, D)
 
-        assert np.alltrue(d.kl_divergence(d2) >= 0)
+        assert np.all(d.kl_divergence(d2) >= 0)
         
     @pytest.mark.parametrize("R, D, Dsum", [(1, 5, 2), (1, 5, 1), (1, 3, 2), (1, 3, 5)])
     def test_get_density_of_linear_sum(self, R, D, Dsum):

--- a/tests/test_pdf.py
+++ b/tests/test_pdf.py
@@ -5,6 +5,9 @@ from jax import numpy as jnp
 import numpy as np
 from scipy.stats import multivariate_normal
 import jax
+from jax import config
+config.update("jax_enable_x64", True)
+np.random.seed(0)
 
 
 class TestGaussianPDF:

--- a/tests/test_pdf.py
+++ b/tests/test_pdf.py
@@ -168,7 +168,7 @@ class TestGaussianPDF:
             d_sum = d.get_density_of_linear_sum(W, b)
             key = jax.random.PRNGKey(0)
             subkey, key = jax.random.split(key)
-            d_sample = d.sample(subkey, num_samples=100000)[:,0]
+            d_sample = d.sample(subkey, num_samples=1000000)[:,0]
             W_d_sample  = jnp.einsum("abc,ac->ab", W, d_sample)
             sum_sampled_mean = jnp.mean(W_d_sample + b, axis=0, keepdims=True)
             var_sampled_mean = jnp.mean(jnp.einsum("ab,ac->abc", W_d_sample + b, W_d_sample + b), axis=0, keepdims=True)

--- a/tests/test_pdf.py
+++ b/tests/test_pdf.py
@@ -155,7 +155,34 @@ class TestGaussianPDF:
         d2 = self.create_instance(R, D)
 
         assert np.alltrue(d.kl_divergence(d2) >= 0)
-
+        
+    @pytest.mark.parametrize("R, D, Dsum", [(1, 5, 2), (1, 5, 1), (1, 3, 2), (1, 3, 5)])
+    def test_get_density_of_linear_sum(self, R, D, Dsum):
+        d = self.create_instance(R, D)
+        W = jnp.array(np.random.randn(R, Dsum, D))
+        b = jnp.array(np.random.randn(R, Dsum))
+        if Dsum <= D:
+            d_sum = d.get_density_of_linear_sum(W, b)
+            key = jax.random.PRNGKey(0)
+            subkey, key = jax.random.split(key)
+            d_sample = d.sample(subkey, num_samples=100000)[:,0]
+            W_d_sample  = jnp.einsum("abc,ac->ab", W, d_sample)
+            sum_sampled_mean = jnp.mean(W_d_sample + b, axis=0, keepdims=True)
+            var_sampled_mean = jnp.mean(jnp.einsum("ab,ac->abc", W_d_sample + b, W_d_sample + b), axis=0, keepdims=True)
+            var_sampled_mean -= jnp.einsum("ab,ac->abc", sum_sampled_mean, sum_sampled_mean)
+            assert jnp.allclose(d_sum.mu, sum_sampled_mean, rtol=1e-1, atol=1e-2)
+            assert jnp.allclose(d_sum.Sigma, var_sampled_mean, rtol=1e-1, atol=1e-2)
+            # When b is not sepcified
+            d_sum = d.get_density_of_linear_sum(W)
+            W_d_sample  = jnp.einsum("abc,ac->ab", W, d_sample)
+            sum_sampled_mean = jnp.mean(W_d_sample, axis=0, keepdims=True)
+            var_sampled_mean = jnp.mean(jnp.einsum("ab,ac->abc", W_d_sample, W_d_sample), axis=0, keepdims=True)
+            var_sampled_mean -= jnp.einsum("ab,ac->abc", sum_sampled_mean, sum_sampled_mean)
+            assert jnp.allclose(d_sum.mu, sum_sampled_mean, rtol=1e-1, atol=1e-2)
+            assert jnp.allclose(d_sum.Sigma, var_sampled_mean, rtol=1e-1, atol=1e-2)
+        else:
+            with pytest.raises(AssertionError):
+                d_sum = d.get_density_of_linear_sum(W, b)
 
 class TestGaussianDiagPDF(TestGaussianPDF):
     def setup_class(self):


### PR DESCRIPTION
This pull request includes several changes to improve the development environment, documentation, and examples for the Gaussian Toolbox project. The most important changes include the addition of a development container, updates to the documentation workflow, and various documentation and example improvements.

Improvements to development environment:

* [`.devcontainer/Dockerfile`](diffhunk://#diff-13bd9d7a30bf46656bc81f1ad5b908a627f9247be3f7d76df862b0578b534fc6R1-R13): Added a Dockerfile to set up a development container with Python 3.11 and necessary dependencies.
* [`.devcontainer/devcontainer.json`](diffhunk://#diff-24ad71c8613ddcf6fd23818cb3bb477a1fb6d83af4550b0bad43099813088686R1-R19): Added a configuration file for the development container, specifying the Dockerfile and VS Code extensions.

Updates to documentation workflow:

* [`.github/workflows/docs.yml`](diffhunk://#diff-9cf2000c53760d837a449f874e53f792819108d3a4bf346336d0f7d082deae2cL2-R8): Modified the documentation workflow to trigger only on changes to the main branch.

Documentation improvements:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R6-R8): Updated links to documentation to point to the correct URLs. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R6-R8) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L76-R81)
* [`docs/source/gaussian_toolbox.rst`](diffhunk://#diff-f2195a5baf1330b28d181d215bc3b56a1386663460654173e2f0ccefb64d9204L8-R51): Added new submodules and adjusted the documentation structure for better navigation.

Example improvements:

* [`examples/affine_transforms.ipynb`](diffhunk://#diff-c16453096152d8e26689c0b74a3bf8c91ecdb373ad1ce12dcde08854007de181L248-R248): Updated the Python version in the notebook metadata. [[1]](diffhunk://#diff-c16453096152d8e26689c0b74a3bf8c91ecdb373ad1ce12dcde08854007de181L248-R248) [[2]](diffhunk://#diff-c16453096152d8e26689c0b74a3bf8c91ecdb373ad1ce12dcde08854007de181L262-R262)
* [`examples/linear_regression.ipynb`](diffhunk://#diff-2f8fb57af80f40949471101e71ebc35d7d7e93dfbc7e927043e36b7ad9ad4b0aL5-R5): Standardized cell IDs for better consistency and readability. [[1]](diffhunk://#diff-2f8fb57af80f40949471101e71ebc35d7d7e93dfbc7e927043e36b7ad9ad4b0aL5-R5) [[2]](diffhunk://#diff-2f8fb57af80f40949471101e71ebc35d7d7e93dfbc7e927043e36b7ad9ad4b0aL25-R25) [[3]](diffhunk://#diff-2f8fb57af80f40949471101e71ebc35d7d7e93dfbc7e927043e36b7ad9ad4b0aL40-R40) [[4]](diffhunk://#diff-2f8fb57af80f40949471101e71ebc35d7d7e93dfbc7e927043e36b7ad9ad4b0aL70-R70) [[5]](diffhunk://#diff-2f8fb57af80f40949471101e71ebc35d7d7e93dfbc7e927043e36b7ad9ad4b0aL79-R79) [[6]](diffhunk://#diff-2f8fb57af80f40949471101e71ebc35d7d7e93dfbc7e927043e36b7ad9ad4b0aL108-R108) [[7]](diffhunk://#diff-2f8fb57af80f40949471101e71ebc35d7d7e93dfbc7e927043e36b7ad9ad4b0aL124-R124) [[8]](diffhunk://#diff-2f8fb57af80f40949471101e71ebc35d7d7e93dfbc7e927043e36b7ad9ad4b0aL205-R205) [[9]](diffhunk://#diff-2f8fb57af80f40949471101e71ebc35d7d7e93dfbc7e927043e36b7ad9ad4b0aL221-R221) [[10]](diffhunk://#diff-2f8fb57af80f40949471101e71ebc35d7d7e93dfbc7e927043e36b7ad9ad4b0aL259-R259) [[11]](diffhunk://#diff-2f8fb57af80f40949471101e71ebc35d7d7e93dfbc7e927043e36b7ad9ad4b0aL272-R272) [[12]](diffhunk://#diff-2f8fb57af80f40949471101e71ebc35d7d7e93dfbc7e927043e36b7ad9ad4b0aL301-R301) [[13]](diffhunk://#diff-2f8fb57af80f40949471101e71ebc35d7d7e93dfbc7e927043e36b7ad9ad4b0aL316-R316) [[14]](diffhunk://#diff-2f8fb57af80f40949471101e71ebc35d7d7e93dfbc7e927043e36b7ad9ad4b0aL351-R351) [[15]](diffhunk://#diff-2f8fb57af80f40949471101e71ebc35d7d7e93dfbc7e927043e36b7ad9ad4b0aL368-R368) [[16]](diffhunk://#diff-2f8fb57af80f40949471101e71ebc35d7d7e93dfbc7e927043e36b7ad9ad4b0aL383-R391) [[17]](diffhunk://#diff-2f8fb57af80f40949471101e71ebc35d7d7e93dfbc7e927043e36b7ad9ad4b0aL400-R400) [[18]](diffhunk://#diff-2f8fb57af80f40949471101e71ebc35d7d7e93dfbc7e927043e36b7ad9ad4b0aL437-R437)
* [`examples/timeseries.ipynb`](diffhunk://#diff-18a9faf05eb160ce4543779f167bfdcf3d5433c9559b2530e915264e31bd9467L6-R6): Standardized cell IDs for better consistency and readability. [[1]](diffhunk://#diff-18a9faf05eb160ce4543779f167bfdcf3d5433c9559b2530e915264e31bd9467L6-R6) [[2]](diffhunk://#diff-18a9faf05eb160ce4543779f167bfdcf3d5433c9559b2530e915264e31bd9467L37-R37) [[3]](diffhunk://#diff-18a9faf05eb160ce4543779f167bfdcf3d5433c9559b2530e915264e31bd9467L59-R59) [[4]](diffhunk://#diff-18a9faf05eb160ce4543779f167bfdcf3d5433c9559b2530e915264e31bd9467L68-R68) [[5]](diffhunk://#diff-18a9faf05eb160ce4543779f167bfdcf3d5433c9559b2530e915264e31bd9467L107-R107) [[6]](diffhunk://#diff-18a9faf05eb160ce4543779f167bfdcf3d5433c9559b2530e915264e31bd9467L126-R126)